### PR TITLE
Highlight paired brackets

### DIFF
--- a/src/js/aceHelpers.js
+++ b/src/js/aceHelpers.js
@@ -141,36 +141,29 @@
 
     var highlightBracketsOverride = function(Range) {
         var {session} = this;
+        if (!session || !session.bgTokenizer) { return; }
         if (session.$bracketHighlight) { // Remove highlighting and set vars undefined
-            session.$bracketHighlight = session.removeMarker(this.session.$bracketHighlight);
-            session.$bracketHighlightMatch = session.removeMarker(this.session.$bracketHighlightMatch);
+            session.$bracketHighlight = session.removeMarker(session.$bracketHighlight);
+            session.$bracketHighlightMatch = session.removeMarker(session.$bracketHighlightMatch);
         }
-        if (this.$highlightPending) {
-            return;
-        }
-        this.$highlightPending = true;
-        setTimeout(() => {
-            this.$highlightPending = false;
-            if (!session || !session.bgTokenizer) { return; }
-            var cursorPos = this.getCursorPosition();
-            cursorPos.column += 1; // Look for right-side bracket first
-            var matchPos = session.findMatchingBracket(cursorPos);
-            var matchRange;
+        var cursorPos = this.getCursorPosition();
+        cursorPos.column += 1; // Look for right-side bracket first
+        var matchPos = session.findMatchingBracket(cursorPos);
+        var matchRange;
+        if (matchPos) {
+            matchRange = new Range(matchPos.row, matchPos.column, matchPos.row, matchPos.column + 1);
+        } else { // No right-side bracket, check left
+            cursorPos.column -= 1;
+            matchPos = session.findMatchingBracket(cursorPos);
             if (matchPos) {
                 matchRange = new Range(matchPos.row, matchPos.column, matchPos.row, matchPos.column + 1);
-            } else { // No right-side bracket, check left
-                cursorPos.column -= 1;
-                matchPos = session.findMatchingBracket(cursorPos);
-                if (matchPos) {
-                    matchRange = new Range(matchPos.row, matchPos.column, matchPos.row, matchPos.column + 1);
-                }
             }
-            if (matchRange) {
-                var cursorRange = new Range(cursorPos.row, cursorPos.column - 1, cursorPos.row, cursorPos.column);
-                session.$bracketHighlight = session.addMarker(cursorRange, 'ace_bracket', 'text');
-                session.$bracketHighlightMatch = session.addMarker(matchRange, 'ace_bracket', 'text');
-            }
-        }, 50);
+        }
+        if (matchRange) {
+            var cursorRange = new Range(cursorPos.row, cursorPos.column - 1, cursorPos.row, cursorPos.column);
+            session.$bracketHighlight = session.addMarker(cursorRange, 'ace_bracket', 'text');
+            session.$bracketHighlightMatch = session.addMarker(matchRange, 'ace_bracket', 'text');
+        }
     };
 
     /**

--- a/src/styl/3rdParty/ace.styl
+++ b/src/styl/3rdParty/ace.styl
@@ -1,3 +1,5 @@
+.ace_bracket
+    background lightgray
 if (theme == 'Night')
     .ace-ambiance
         &.ace-ambiance
@@ -17,3 +19,5 @@ if (theme == 'Night')
             background none
         .ace_gutter-active-line.ace_gutter-active-line
             background rgba(act, 0.075)
+        .ace_bracket
+            background #333


### PR DESCRIPTION
Closes #104

Lints and builds fine, and seems to do what it's supposed to. I found a way to grab the `Range` constructor out of ace so I was able to override `highlightBrackets` without touching ace.js.

I tried to keep it current with your develop branch but I missed your last commit by a couple minutes. I also butchered the commit emoji, sorry!

**Ping @CosmoMyzrailGorynych**
