### PR TITLE
:sparkles: Destroy nested copies 

### DIFF
--- a/app/data/ct.release/main.js
+++ b/app/data/ct.release/main.js
@@ -1,7 +1,7 @@
 /* Made with ct.js http://ctjs.rocks/ */
-const deadPool = new Set(); // a pool of `kill`-ed copies for delaying frequent garbage collection
+const deadPool = []; // a pool of `kill`-ed copies for delaying frequent garbage collection
 setInterval(function () {
-    deadPool.clear();
+    deadPool.length = 0;
 }, 1000 * 60);
 
 const ct = {
@@ -225,7 +225,7 @@ ct.loop = function(delta) {
             copy.kill = true;
             ct.types.onDestroy.apply(copy);
             copy.onDestroy.apply(copy);
-            deadPool.add(copy);
+            deadPool.push(copy);
         }
     }
     removeKilledCopies(ct.stack);

--- a/app/data/ct.release/main.js
+++ b/app/data/ct.release/main.js
@@ -229,16 +229,6 @@ ct.loop = function(delta) {
         ct.types.list[i] = ct.types.list[i].filter(type => !type.kill);
     }
 
-    // ct.types.list[type: String]
-    for (const i in ct.types.list) {
-        for (let k = 0, lk = ct.types.list[i].length; k < lk; k++) {
-            if (ct.types.list[i][k].kill) {
-                ct.types.list[i].splice(k, 1);
-                k--; lk--;
-            }
-        }
-    }
-
     for (const cont of ct.stage.children) {
         cont.children.sort((a, b) =>
             ((a.depth || 0) - (b.depth || 0)) || ((a.uid || 0) - (b.uid || 0)) || 0

--- a/app/data/ct.release/main.js
+++ b/app/data/ct.release/main.js
@@ -205,7 +205,7 @@ ct.loop = function(delta) {
     // copies
     const killCopy = copy => {
         for (const child of copy.children) {
-            if (child instanceof ct.types.Copy) {
+            if (child instanceof ct.types.Copy && !child.kill) {
                 child.kill = true;
                 killCopy(child);
             }

--- a/app/data/ct.release/main.js
+++ b/app/data/ct.release/main.js
@@ -216,12 +216,12 @@ ct.loop = function(delta) {
     ct.rooms.afterStep.apply(ct.room);
     // copies
     for (let i = 0; i < ct.stack.length; i++) {
-        if (ct.stack[i].kill) {
+        if (ct.stack[i].kill && !ct.stack[i]._destroyed) {
             ct.stack[i].destroy({children: true});
         }
     }
     for (const copy of ct.stack) {
-        if (!copy.parent) {
+        if (copy._destroyed) {
             copy.kill = true;
             ct.types.onDestroy.apply(copy);
             copy.onDestroy.apply(copy);


### PR DESCRIPTION
**Changes proposed in this pull request:**
- When a copy is destroyed, all its children are destroyed too.
- Use filter in place instead of multiple splice()

**Ping @CosmoMyzrailGorynych**
