### PR TITLE
Add missing quotation mark in mouse catmod changelog

### DIFF
--- a/app/data/ct.libs/mouse/CHANGELOG.md
+++ b/app/data/ct.libs/mouse/CHANGELOG.md
@@ -2,7 +2,7 @@ v3.0.0
 
 * Support the new ct.camera object
 * Introduce `ct.mouse.xui`, `ct.mouse.yui`, as well as `ct.mouse.xuiprev` and `ct.mouse.yuiprev`
-* Remove `ct.mouse.rx` and `ct.mouse.ry
+* Remove `ct.mouse.rx` and `ct.mouse.ry`
 * Fix broken `Wheel` input method
 
 v2.0.0


### PR DESCRIPTION
Quick fix for the CHANGELOG.md of mouse catmod.