### PR TITLE
🐛  fix #276

### DIFF
--- a/src/styl/tags/textures/texture-editor.styl
+++ b/src/styl/tags/textures/texture-editor.styl
@@ -51,7 +51,7 @@ texture-editor
     padding 0
 
 .textureview-tools
-    position absolute
+    position relative
     top 0.5em
     right 0.5em
     .file


### PR DESCRIPTION
Fixes (partially) #276.

By changing the positioning of `.textureview-tools` the black bar seems disappear

https://user-images.githubusercontent.com/33903092/115157203-434c4380-a088-11eb-821e-352b6abf1d54.mov

<!-- I get spammed by your upstream pulls 😹 -->
**Ping @CosmoMyzrailGorynych**
