### PR TITLE
Simple macOS fixes including bumped nwVersion

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,7 +45,7 @@ const path = require('path'),
  */
 const nwSource = void 0;
 const nwManifest = void 0;
-const nwVersion = '0.51.2',
+const nwVersion = '0.53.1',
       platforms = ['osx64', 'win32', 'win64', 'linux32', 'linux64'],
       nwFiles = ['./app/**', '!./app/export/**', '!./app/projects/**', '!./app/exportDesktop/**', '!./app/cache/**', '!./app/.vscode/**', '!./app/JamGames/**'];
 
@@ -307,7 +307,7 @@ const lintI18n = () => require('./node_requires/i18n')().then(console.log);
 const lint = gulp.series(lintJS, lintTags, lintStylus, lintI18n);
 
 const processToPlatformMap = {
-    'darwin-x64': 'darwin',
+    'darwin-x64': 'osx64',
     'win32-x32': 'win32',
     'win32-x64': 'win64',
     'linux-x32': 'linux32',

--- a/src/node_requires/resources/projects/index.ts
+++ b/src/node_requires/resources/projects/index.ts
@@ -16,6 +16,10 @@ const getExamplesDir = function (): string {
         // Most likely, we are in a dev environment
         return path.join((nw.App as any).startPath, 'src/examples');
     } catch (e) {
+        const {isMac} = require('./../../platformUtils');
+        if (isMac) {
+            return path.join(process.cwd(), 'examples');
+        }
         return path.join((nw.App as any).startPath, 'examples');
     }
 };


### PR DESCRIPTION
Hi @CosmoMyzrailGorynych,

Like what you've done here. I'm just going through a few macOS fixes - you can merge them now or later or just rewrite them yourself. I'll explain each:

**nwVersion bump**

The macOS version displays unsightly black boxes. Chromium graphics acceleration drivers frequently jump into (and out of) bugs with each version on all platforms. There are two fixes to this problem: pass `--disable-gpu` to nw-builder or jump to the latest version of Chromium. I picked the latter. The below is from the 1.7.0 build.

![image](https://user-images.githubusercontent.com/52765023/118345426-c1144980-b577-11eb-8350-2401c86e6d7c.png)

**processToPlatformMap**

This is more a typo than anything else.

**Example projects path**

For the macOS, `path.join((nw.App as any).startPath, 'examples');` returns `/examples`. A better place to look for example projects is `ctjs.app/Contents/Resources/app.nw/examples`. Word of caution, if `ctjs.app` then modifies those projects in-place I'm not sure how macOS is going to react to that.

**Finder preferences destroyed by nw-builder** ⚠️ not fixed ⚠️

The Finder loses its preferences upon running `gulp packages`. This can lead briefly to the developer thinking files have been deleted. It's unclear why this is happening. Originally I thought it was because of the [low macOS ulimit](https://www.npmjs.com/package/nw-builder#osx-ulimit) but I have adjusted this setting to no avail. Rest assured any devs reading, as far as I can tell, your files are not deleted but your Finder preferences are sadly destroyed. The issue is unnervingly reproducible. Pic of some of the issue below.

![image](https://user-images.githubusercontent.com/52765023/118352855-19167480-b5a7-11eb-91d1-ee31f2fa6439.png)

Hope you have a great day. I'm sorry I must rush.