### PR TITLE
Example bug fixes

### DIFF
--- a/app/data/ct.libs/touch/index.js
+++ b/app/data/ct.libs/touch/index.js
@@ -127,10 +127,7 @@
         }
     };
     var mouseUp = function () {
-        var ind = findTouchId(-1);
-        if (ind !== -1) {
-            ct.touch.events.splice(ind, 1);
-        }
+        ct.touch.events = ct.touch.events.filter(x => x.id !== -1);
         countTouches();
     };
     ct.touch = {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "doc": "docs"
   },
   "scripts": {
+    "start": "gulp",
     "lint": "gulp lint",
     "docs:dev": "vuepress dev docs",
     "docs:build": "vuepress build docs",

--- a/src/examples/Platformer_tutorial.ict
+++ b/src/examples/Platformer_tutorial.ict
@@ -153,7 +153,7 @@ types:
   - name: Water
     depth: 0
     oncreate: ''
-    onstep: ct.types.move(this);
+    onstep: ''
     ondraw: ''
     ondestroy: ''
     uid: c1aaae5f-3e4c-4e41-8e24-4c2dfe4d43b6
@@ -164,7 +164,7 @@ types:
   - name: Water_Top
     depth: 0
     oncreate: ''
-    onstep: ct.types.move(this);
+    onstep: ''
     ondraw: ''
     ondestroy: ''
     uid: 807691ae-10c5-4cf6-ba0f-6f53d83367ff

--- a/src/examples/SpaceShooter_tutorial.ict
+++ b/src/examples/SpaceShooter_tutorial.ict
@@ -66,7 +66,7 @@ types:
       }
 
 
-      ct.types.move(this);
+      this.move();
     ondraw: ''
     ondestroy: ''
     uid: f5832845-7841-408b-bae7-a72aaffcae6c
@@ -106,7 +106,7 @@ types:
           this.kill = true;
       }
 
-      ct.types.move(this);
+      this.move();
     ondraw: ''
     ondestroy: ''
     uid: cd732ad2-d2ae-4745-b6d8-07a57a9d3a2e
@@ -153,7 +153,7 @@ types:
       this.direction = ct.random.range(90 - 30, 90 + 30);
       this.ctype = 'Hostile';
     onstep: |-
-      ct.types.move(this);
+      this.move();
 
       if (this.y > ct.height + 80) {
           this.kill = true;
@@ -178,7 +178,7 @@ types:
       this.direction = ct.random.range(90 - 30, 90 + 30);
       this.ctype = 'Hostile';
     onstep: |-
-      ct.types.move(this);
+      this.move();
 
       if (this.y > ct.height + 80) {
           this.kill = true;
@@ -273,13 +273,13 @@ rooms:
       this.asteroidTimer -= ct.delta;
       if (this.asteroidTimer <= 0) {
           this.asteroidTimer = ct.random.range(20, 200);
-          ct.types.copy(ct.random.dice('Asteroid_Big', 'Asteroid_Medium'), ct.random(ct.viewWidth), -100);
+          ct.types.copy(ct.random.dice('Asteroid_Big', 'Asteroid_Medium'), ct.random(ct.width), -100);
       }
 
       this.enemyTimer -= ct.delta;
       if (this.enemyTimer <= 0) {
           this.enemyTimer = ct.random.range(180, 400);
-          ct.types.copy('EnemyShip', ct.random(ct.viewWidth), -100);
+          ct.types.copy('EnemyShip', ct.random(ct.width), -100);
       }
     ondraw: |-
       this.scoreLabel.text = 'Score: ' + this.score;

--- a/src/examples/SpaceShooter_tutorial.ict
+++ b/src/examples/SpaceShooter_tutorial.ict
@@ -273,13 +273,13 @@ rooms:
       this.asteroidTimer -= ct.delta;
       if (this.asteroidTimer <= 0) {
           this.asteroidTimer = ct.random.range(20, 200);
-          ct.types.copy(ct.random.dice('Asteroid_Big', 'Asteroid_Medium'), ct.random(ct.width), -100);
+          ct.types.copy(ct.random.dice('Asteroid_Big', 'Asteroid_Medium'), ct.random(ct.camera.width), -100);
       }
 
       this.enemyTimer -= ct.delta;
       if (this.enemyTimer <= 0) {
           this.enemyTimer = ct.random.range(180, 400);
-          ct.types.copy('EnemyShip', ct.random(ct.width), -100);
+          ct.types.copy('EnemyShip', ct.random(ct.camera.width), -100);
       }
     ondraw: |-
       this.scoreLabel.text = 'Score: ' + this.score;

--- a/src/examples/catformer.ict
+++ b/src/examples/catformer.ict
@@ -9,6 +9,7 @@ libs:
   keyboard.polyfill: {}
   keyboard: {}
   vkeys: {}
+  sound.howler: {}
   touch: {}
 types:
   - name: Box

--- a/src/examples/memocats.ict
+++ b/src/examples/memocats.ict
@@ -4,6 +4,7 @@ libs:
   mouse: {}
   fittoscreen:
     mode: scaleFit
+  sound.howler: {}
   tween: {}
 types:
   - name: Card
@@ -110,7 +111,7 @@ types:
       }
 
       if (this.drop) {
-          ct.types.move(this);
+          this.move();
           this.angle += this.rotationSpeed * ct.delta;
           if (this.y > ct.height + 160) {
               this.kill = true;


### PR DESCRIPTION
Still really enjoying this @CosmoMyzrailGorynych!

Got some bigger ideas ahead - we'll see if they work. But for now just some bug fixes for the examples.

Specifically:

* `ct.types.move(this)` to `this.move()` or deleted
* `ct.viewWidth` to `ct.width`
* `sound.howler: {}` added where required

As well as two other changes:

* `npm start` to run `gulp` for those of us not used to `gulp`
* `ct.libs/touch`'s `mouseUp()` to use `.filter(x => x.id !== -1)` to release all mouse events thus preventing a bug when the user's mouse is released but the browser is not informed. Previously this was irrecoverable because an additional mouse press/release would only create and then release the same single event. Now with a mouse press/release cycle releasing all events it becomes the recovery mechanism.

The attached video shows the issue. Mouse button is pressed then released outside the browser window creating the issue. And then repeated click/releases are made inside the browser window to attempt recovery. No recovery is possible in the buggy version (shown), recovery is possible with the `.filter(x => x.id !== -1)` fix.


https://user-images.githubusercontent.com/52765023/121002428-ac6e4e80-c7cf-11eb-8980-10d7f97ff792.mp4

