### PR TITLE
Mac Deletion Fix

### DIFF
--- a/app/data/i18n/Brazilian Portuguese.json
+++ b/app/data/i18n/Brazilian Portuguese.json
@@ -417,6 +417,7 @@
         "gridoff": "Desabilitar grade",
         "gridsize": "Tamanho da grade:",
         "hotkeysNotice": "Ctrl = Apagar, Alt = Sem grade, Shift = Múltiplo",
+        "hotkeysNoticeMac": "Ctrl+Alt = Apagar, Alt = Sem grade, Shift = Múltiplo",
         "hotkeysNoticeMovement": "Ctrl = Apagar, Shift = Selecionar",
         "tocenter": "Centralizar",
         "selectbg": "Selecionar um conjunto de tiles",

--- a/app/data/i18n/Chinese Simplified.json
+++ b/app/data/i18n/Chinese Simplified.json
@@ -483,6 +483,7 @@
         "gridoff": "禁用网格",
         "gridsize": "网格大小:",
         "hotkeysNotice": "Ctrl = 删除, Alt = 无网格, Shift = 多选",
+        "hotkeysNoticeMac": "Ctrl+Alt = 删除, Alt = 无网格, Shift = 多选",
         "hotkeysNoticeMovement": "Ctrl = 删除, Shift = 选择",
         "tocenter": "居中",
         "selectbg": "选择图集",

--- a/app/data/i18n/Comments.json
+++ b/app/data/i18n/Comments.json
@@ -317,6 +317,7 @@
         "gridoff": "",
         "gridsize": "",
         "hotkeysNotice": "",
+        "hotkeysNoticeMac": "",
         "hotkeysNoticeMovement": "",
         "tocenter": "",
         "selectbg": "",

--- a/app/data/i18n/Debug.json
+++ b/app/data/i18n/Debug.json
@@ -317,6 +317,7 @@
         "gridoff": "roomview.gridoff",
         "gridsize": "roomview.gridsize",
         "hotkeysNotice": "roomview.hotkeysNotice",
+        "hotkeysNoticeMac": "roomview.hotkeysNoticeMac",
         "hotkeysNoticeMovement": "roomview.hotkeysNoticeMovement",
         "tocenter": "roomview.tocenter",
         "selectbg": "roomview.selectbg",

--- a/app/data/i18n/Dutch.json
+++ b/app/data/i18n/Dutch.json
@@ -483,6 +483,7 @@
         "gridoff": "Raster uitschakelen",
         "gridsize": "Raster grootte:",
         "hotkeysNotice": "Ctrl = Verwijder, Alt = Geen raster, Shift = Meerdere",
+        "hotkeysNoticeMac": "Ctrl+Alt = Verwijder, Alt = Geen raster, Shift = Meerdere",
         "hotkeysNoticeMovement": "Ctrl = Verwijder, Shift = Selecteer",
         "tocenter": "Centreren",
         "selectbg": "Selecteer tegelset",

--- a/app/data/i18n/English.json
+++ b/app/data/i18n/English.json
@@ -517,6 +517,7 @@
         "gridoff": "Disable grid",
         "gridsize": "Grid size:",
         "hotkeysNotice": "Ctrl = Delete, Alt = No grid, Shift = Multiple",
+        "hotkeysNoticeMac": "Ctrl+Alt = Delete, Alt = No grid, Shift = Multiple",
         "hotkeysNoticeMovement": "Ctrl = Delete, Shift = Select",
         "tocenter": "To center",
         "selectbg": "Select tileset",

--- a/app/data/i18n/French.json
+++ b/app/data/i18n/French.json
@@ -480,6 +480,7 @@
         "gridoff": "Désactiver la grille",
         "gridsize": "Taille de la grille",
         "hotkeysNotice": "Ctrl = Supprimer, Alt = Désactive la grille, Shift = Multiplie",
+        "hotkeysNoticeMac": "Ctrl+Alt = Supprimer, Alt = Désactive la grille, Shift = Multiplie",
         "hotkeysNoticeMovement": "Ctrl = Supprimer, Shift = Sélectionner",
         "tocenter": "Au centre",
         "selectbg": "Selectionner un Tileset",

--- a/app/data/i18n/German.json
+++ b/app/data/i18n/German.json
@@ -483,6 +483,7 @@
         "gridoff": "Raster deaktivieren",
         "gridsize": "Rastergröße:",
         "hotkeysNotice": "Strg = Entfernen, Alt = Kein Raster, Hochstelltaste = Mehrfach",
+        "hotkeysNoticeMac": "Strg+Alt = Entfernen, Alt = Kein Raster, Hochstelltaste = Mehrfach",
         "hotkeysNoticeMovement": "Strg = Löschen, Hochstelltaste = Auswahl",
         "tocenter": "zum Zentrum",
         "selectbg": "Tileset auswählen",

--- a/app/data/i18n/Polish.json
+++ b/app/data/i18n/Polish.json
@@ -395,6 +395,7 @@
         "gridoff": "Zablokuj siatkę",
         "gridsize": "Rozmiar siatki:",
         "hotkeysNotice": "Ctrl = Usuń, Alt = Brak siatki, Shift = Wielokrotnie",
+        "hotkeysNoticeMac": "Ctrl+Alt = Usuń, Alt = Brak siatki, Shift = Wielokrotnie",
         "hotkeysNoticeMovement": "Ctrl = Usuń, Shift = Wybierz",
         "tocenter": "Na środek",
         "selectbg": "Wybierz tileset",

--- a/app/data/i18n/Romanian.json
+++ b/app/data/i18n/Romanian.json
@@ -386,6 +386,7 @@
         "gridoff": "Dezactivează grilă",
         "gridsize": "Mărimea grilei:",
         "hotkeysNotice": "Ctrl = Șterge, Alt = Fără grilă, Shift = Multiplu",
+        "hotkeysNoticeMac": "Ctrl+Alt = Șterge, Alt = Fără grilă, Shift = Multiplu",
         "hotkeysNoticeMovement": "Ctrl = Șterge, Shift = Selectare",
         "tocenter": "La centru",
         "selectbg": "Selectează tileset",

--- a/app/data/i18n/Russian.json
+++ b/app/data/i18n/Russian.json
@@ -464,6 +464,7 @@
         "gridoff": "Выключить сетку",
         "gridsize": "Размер сетки:",
         "hotkeysNotice": "Ctrl = Удалить, Alt = Без сетки, Shift = Много",
+        "hotkeysNoticeMac": "Ctrl+Alt = Удалить, Alt = Без сетки, Shift = Много",
         "hotkeysNoticeMovement": "Ctrl = Удалить, Shift = Выделить",
         "tocenter": "В центр",
         "selectbg": "Выбрать тайлсет",

--- a/app/data/i18n/Spanish.json
+++ b/app/data/i18n/Spanish.json
@@ -386,6 +386,7 @@
         "gridoff": "Deshabilitar cuadrícula",
         "gridsize": "Tamaño de la cuadrícula:",
         "hotkeysNotice": "Ctrl = Eliminar, Alt = Sin cuadrícula, Shift = Múltiple",
+        "hotkeysNoticeMac": "Ctrl+Alt = Eliminar, Alt = Sin cuadrícula, Shift = Múltiple",
         "hotkeysNoticeMovement": "Ctrl = Eliminar, Shift = Seleccionar",
         "tocenter": "Al centro",
         "selectbg": "Seleccionar tileset",

--- a/src/js/roomCopyTools.js
+++ b/src/js/roomCopyTools.js
@@ -1,6 +1,7 @@
 (function roomCopyTools() {
     const clickThreshold = 10;
     const glob = require('./data/node_requires/glob');
+    const isMac = navigator.platform.indexOf('Mac') !== -1;
 
     const drawInsertPreview = function (e) {
         let img, texture, w, h, grax, gray, ox, oy;
@@ -230,7 +231,7 @@
             };
             /* eslint max-depth: 0 */
             this.onCanvasMoveCopies = e => {
-                if (e.ctrlKey) {
+                if (e.ctrlKey && (!isMac || e.altKey)) {
                     if (this.mouseDown && this.room.copies.length !== 0) {
                         var l,
                             fromx = this.xToRoom(e.offsetX),

--- a/src/js/roomCopyTools.js
+++ b/src/js/roomCopyTools.js
@@ -229,7 +229,7 @@
                     }
                 }
             };
-            /* eslint max-depth: 0 */
+            // eslint-disable-next-line complexity
             this.onCanvasMoveCopies = e => {
                 if (e.ctrlKey && (!isMac || e.altKey)) {
                     if (this.mouseDown && this.room.copies.length !== 0) {

--- a/src/js/roomTileTools.js
+++ b/src/js/roomTileTools.js
@@ -1,6 +1,7 @@
 (function roomTileTools() {
     const clickThreshold = 10;
     const glob = require('./data/node_requires/glob');
+    const isMac = navigator.platform.indexOf('Mac') !== -1;
 
     const selectATileAt = function (e) {
         var pos = 0,
@@ -47,7 +48,7 @@
     };
     const onCanvasMoveTiles = function (e) {
         // if we delete tiles
-        if (e.ctrlKey) {
+        if (e.ctrlKey && (!isMac || e.altKey)) {
             // and the mouse is held down
             if (this.mouseDown && this.currentTileLayer) {
                 var pos = 0,

--- a/src/riotTags/rooms/room-editor.tag
+++ b/src/riotTags/rooms/room-editor.tag
@@ -535,22 +535,24 @@ room-editor.panel.view
             return true;
         };
 
-        this.sortHorizontally = () => {
+        this.sortHorizontally = (e) => {
+            const altKey = e && e.altKey;
             if (this.tab === 'roomcopies') {
-                this.room.copies.sort((a, b) => a.x - b.x);
+                this.room.copies.sort((a, b) => (a.x - b.x) * (altKey ? -1 : 1));
             } else {
                 // tiles
-                this.currentTileLayer.tiles.sort((a, b) => a.x - b.x);
+                this.currentTileLayer.tiles.sort((a, b) => (a.x - b.x) * (altKey ? -1 : 1));
             }
             this.resortRoom();
             this.refreshRoomCanvas();
         };
-        this.sortVertically = () => {
+        this.sortVertically = (e) => {
+            const altKey = e && e.altKey;
             if (this.tab === 'roomcopies') {
-                this.room.copies.sort((a, b) => a.y - b.y);
+                this.room.copies.sort((a, b) => (a.y - b.y) * (altKey ? -1 : 1));
             } else {
                 // tiles
-                this.currentTileLayer.tiles.sort((a, b) => a.y - b.y);
+                this.currentTileLayer.tiles.sort((a, b) => (a.y - b.y) * (altKey ? -1 : 1));
             }
             this.resortRoom();
             this.refreshRoomCanvas();

--- a/src/riotTags/rooms/room-editor.tag
+++ b/src/riotTags/rooms/room-editor.tag
@@ -456,9 +456,9 @@ room-editor.panel.view
         };
 
         this.onCanvasContextMenu = e => {
-            if (this.isMac && e.altKey)  {
+            if (this.isMac && e.altKey) {
                 e.preventDefault();
-                return true; 
+                return true;
             }
             this.dragging = false;
             this.mouseDown = false;

--- a/src/riotTags/rooms/room-editor.tag
+++ b/src/riotTags/rooms/room-editor.tag
@@ -133,7 +133,7 @@ room-editor.panel.view
             )
                 svg.feather
                     use(xlink:href="data/icons.svg#sort-vertical")
-            span(if="{window.innerWidth - sidebarWidth > 940}") {voc.hotkeysNotice}
+            span(if="{window.innerWidth - sidebarWidth > 940}") {isMac ? voc.hotkeysNoticeMac : voc.hotkeysNotice}
         .zoom.flexrow
             b(if="{window.innerWidth - sidebarWidth > 980}") {vocGlob.zoom}:
             .spacer
@@ -196,6 +196,7 @@ room-editor.panel.view
             document.removeEventListener('mouseup', gutterUp);
         });
 
+        this.isMac = navigator.platform.indexOf('Mac') !== -1;
         this.editingCode = false;
         this.forbidDrawing = false;
         const fs = require('fs-extra');
@@ -455,6 +456,10 @@ room-editor.panel.view
         };
 
         this.onCanvasContextMenu = e => {
+            if (this.isMac && e.altKey)  {
+                e.preventDefault();
+                return true; 
+            }
             this.dragging = false;
             this.mouseDown = false;
             if (this.tab === 'roomcopies') {


### PR DESCRIPTION
Hi @CosmoMyzrailGorynych,

Macs have never had a visually distinct second button. Even today, while the mice are programmable to two buttons there is no visually distinct second button. (https://www.apple.com/au/shop/product/MRME2ZA/A/magic-mouse-2-space-grey)

While the majority of Mac users will program/use a two-button mouse, they have to buy one or change a setting in the System Preferences. As a result all context menus and second button actions happen using the control-key and a click.

This is a problem when deleting (control-clicking) because **nwjs** dutifully displays the context menu which then blocks the subsequent deletions meant to take place.

I thought about alternate key combos but decided to go with making the Mac Ctrl+Alt. While minor this fixes an annoying glitch. The pic is of the glitch (not the fix).

I also added a reverse sort to the sprite sorting using the Alt key to all platforms. This is an esoteric feature but is sometimes handy. For the game I was working on I needed the spikes/coins to appear behind the crates - this was the reverse of the default sort implemented.

![Screen Shot 2021-06-13 at 6 13 45 pm](https://user-images.githubusercontent.com/52765023/121800130-69025d00-cc73-11eb-979c-ea3c2f1f76b6.png)

