### PR TITLE
:wrench: (v1.x) Fixed launch.json to work with nwjs extension.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,9 +8,12 @@
             "type": "nwjs",
             "request": "launch",
             "name": "Launch ct.js",
-            "nwjsVersion": "0.34.5",
-            "webRoot": "${workspaceFolder}/app",
-            "reloadAfterAttached": true
+            "nwjsVersion": "0.51.2",
+            "runtimeArgs": [
+                "--nwapp=${workspaceFolder}/app"
+            ],
+            "webRoot": "${workspaceFolder}",
+            "reloadAfterAttached": false
         }
     ]
 }

--- a/package.json
+++ b/package.json
@@ -58,5 +58,6 @@
   "devDependencies": {
     "eslint-plugin-pug": "^1.2.2",
     "gulp-ext-replace": "^0.3.0"
-  }
+  },
+  "main": "index.html"
 }


### PR DESCRIPTION
NOTE: This is cherry picked from the analogous change in develop, which I've also created a pull request, to save maintainers the trouble down the line.

:wrench: (Cherry pick from develop) Fixed launch.json to work with nwjs extension. Also committing autogenerated change to package.json.

**Changes proposed in this pull request:**

In `launch.json`:

- Update NW.js version to match the version specified in gulpfile.
- Set `webRoot` to the workspace root to fix pathfinding issues. This should only affect running via VS Code, and not via gulp.
- To make sure running in VS Code still works, pass the app folder to NW.js via `runtimeArgs`.
- Set reloadAfterAttached to false. When true, it doesn't appear to work correctly anyway, and just kills NW.js and restarts again, which defeats the purpose. Doing this should somewhat reduce beginning debugging by a few seconds.

In `package.json`:

- Committed an auto-generated line pointing to `index.html`. This appears to be inserted by the NW.js extension, and it's better to codify it, just in case the extension maintainers have the bright idea of changing it down the line.

**Ping @CosmoMyzrailGorynych**
