### PR TITLE
🔧 (develop) Fixed launch.json to work with nwjs extension

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,9 +8,12 @@
             "type": "nwjs",
             "request": "launch",
             "name": "Launch ct.js",
-            "nwjsVersion": "0.45.6",
-            "webRoot": "${workspaceFolder}/app",
-            "reloadAfterAttached": true
+            "nwjsVersion": "0.53.1",
+            "runtimeArgs": [
+                "--nwapp=${workspaceFolder}/app"
+            ],
+            "webRoot": "${workspaceFolder}",
+            "reloadAfterAttached": false
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ gulp -f devSetup.gulpfile.js
 gulp
 ```
 
-VSCode can use [this extension](https://marketplace.visualstudio.com/items?itemName=ruakr.vsc-nwjs) to run ct.js with an attached debugger. Use `gulp dev` instead of just `gulp` to run a dev service with live-reloading without opening ct.js in its default manner.
+Use `gulp dev` instead of just `gulp` to run a dev service with live-reloading without opening ct.js in its default manner. In either case, you can stop this service in the usual manner for your terminal, e.g. `Ctrl+C`. If you are encountering unexplained issues, especially when switching to a new branch, run `gulp -f devSetup.gulpfile.js` again.
+
+VSCode can use [this extension](https://marketplace.visualstudio.com/items?itemName=ruakr.vsc-nwjs) to run ct.js with an attached debugger. Before running the debugger, to allow live-reloading, run `gulp dev`.
 
 ## Releasing ct.js
 

--- a/package.json
+++ b/package.json
@@ -59,5 +59,6 @@
   "devDependencies": {
     "eslint-plugin-pug": "^1.2.2",
     "gulp-ext-replace": "^0.3.0"
-  }
+  },
+  "main": "index.html"
 }


### PR DESCRIPTION
:wrench: Fixed launch.json to work with nwjs extension. Also committing autogenerated change to package.json.

Changes proposed in this pull request:

In launch.json:

- Update NW.js version to match the version specified in gulpfile.
- Set webRoot to the workspace root to fix pathfinding issues. This should only affect running via VS Code, and not via gulp.
- To make sure running in VS Code still works, pass the app folder to NW.js via runtimeArgs.
- Set reloadAfterAttached to false. When true, it doesn't appear to work correctly anyway, and just kills NW.js and restarts again, which defeats the purpose. Doing this should somewhat reduce beginning debugging by a few seconds.

In package.json:

- Committed an auto-generated line pointing to index.html. This appears to be inserted by the NW.js extension, and it's better to codify it, just in case the extension maintainers have the bright idea of changing it down the line.

Ping @CosmoMyzrailGorynych