### PR TITLE
:wrench: #306 Made exit button text for all editors Apply, except for Room event editor.

### DIFF
--- a/src/riotTags/rooms/room-editor.tag
+++ b/src/riotTags/rooms/room-editor.tag
@@ -102,7 +102,7 @@ room-editor.panel.view
             button.wide#roomviewdone(onclick="{roomSave}")
                 svg.feather
                     use(xlink:href="data/icons.svg#check")
-                span {window.languageJSON.common.apply}
+                span {vocGlob.apply}
     .aResizer.vertical(ref="gutter" onmousedown="{gutterMouseDown}")
     .editor(ref="canvaswrap")
         canvas(

--- a/src/riotTags/rooms/room-editor.tag
+++ b/src/riotTags/rooms/room-editor.tag
@@ -102,7 +102,7 @@ room-editor.panel.view
             button.wide#roomviewdone(onclick="{roomSave}")
                 svg.feather
                     use(xlink:href="data/icons.svg#check")
-                span {voc.done}
+                span {window.languageJSON.common.apply}
     .aResizer.vertical(ref="gutter" onmousedown="{gutterMouseDown}")
     .editor(ref="canvaswrap")
         canvas(

--- a/src/riotTags/sound-editor.tag
+++ b/src/riotTags/sound-editor.tag
@@ -29,7 +29,7 @@ sound-editor.panel.view
             button.wide(onclick="{soundSave}" title="Shift+Control+S" data-hotkey="Control+S")
                 svg.feather
                     use(xlink:href="data/icons.svg#check")
-                span {voc.save}
+                span {window.languageJSON.common.apply}
     script.
         const path = require('path');
         const fs = require('fs-extra');

--- a/src/riotTags/sound-editor.tag
+++ b/src/riotTags/sound-editor.tag
@@ -29,7 +29,7 @@ sound-editor.panel.view
             button.wide(onclick="{soundSave}" title="Shift+Control+S" data-hotkey="Control+S")
                 svg.feather
                     use(xlink:href="data/icons.svg#check")
-                span {window.languageJSON.common.apply}
+                span {vocGlob.apply}
     script.
         const path = require('path');
         const fs = require('fs-extra');

--- a/src/riotTags/textures/texture-editor.tag
+++ b/src/riotTags/textures/texture-editor.tag
@@ -76,8 +76,8 @@ texture-editor.panel.view
             .flexfix-footer
                 button.wide(onclick="{textureSave}" title="Shift+Control+S" data-hotkey="Control+S")
                     svg.feather
-                        use(xlink:href="data/icons.svg#save")
-                    span {window.languageJSON.common.save}
+                        use(xlink:href="data/icons.svg#check")
+                    span {window.languageJSON.common.apply}
         .texture-editor-anAtlas.tall(
             if="{opts.texture}"
             style="background-color: {previewColor};"

--- a/src/riotTags/textures/texture-editor.tag
+++ b/src/riotTags/textures/texture-editor.tag
@@ -77,7 +77,7 @@ texture-editor.panel.view
                 button.wide(onclick="{textureSave}" title="Shift+Control+S" data-hotkey="Control+S")
                     svg.feather
                         use(xlink:href="data/icons.svg#check")
-                    span {window.languageJSON.common.apply}
+                    span {vocGlob.apply}
         .texture-editor-anAtlas.tall(
             if="{opts.texture}"
             style="background-color: {previewColor};"


### PR DESCRIPTION
Addresses task under #306.

**Changes proposed in this pull request:**

- Make the buttons to exit each editor have a checkmark, followed by the text "Apply", since they all do the same thing (exit editor without saving), and this term is descriptive.

**Help wanted:**

- Specifically left out room editor, since it's unclear whether the button functionality there will line up with its parent editor following completion of #306.


**Ping @CosmoMyzrailGorynych**
