### PR TITLE
:wrench: Texture editor buttons along bottom now visible

### DIFF
--- a/src/styl/tags/textures/texture-editor.styl
+++ b/src/styl/tags/textures/texture-editor.styl
@@ -20,7 +20,7 @@ texture-editor
         margin 1rem
 .texture-editor-aCanvasWrap
     width 100%
-    height 100%
+    height 90%
     overflow scroll
     position relative
 


### PR DESCRIPTION
:wrench: Texture editor buttons along bottom now visible without scrolling.

### Changes proposed in this pull request:
- Prevent texture preview canvas from taking up entire height of tab, so we can see the re-import, etc. buttons below without scrolling.

### Help wanted:
- Test on Windows. This has been tested on Linux.
- Test on different resolutions. This has been tested on 1920x1080 FHD.

**Ping @CosmoMyzrailGorynych**
