### PR TITLE
🐛 Fix Template Inheritance module

### DIFF
--- a/app/data/ct.libs/inherit/injections/onbeforecreate.js
+++ b/app/data/ct.libs/inherit/injections/onbeforecreate.js
@@ -1,40 +1,40 @@
-if ((this instanceof ct.templates.Copy) && this.inheritedTemplate) {
+if ((this instanceof ct.templates.Copy) && this.inheritedType) {
     this.inherit = {
         onCreate: () => {
             const oldTemplate = this.template,
-                  oldInherited = this.inheritedTemplate;
-            this.template = this.inheritedTemplate;
-            this.inheritedTemplate = ct.templates.templates[this.inheritedTemplate].extends.inheritedTemplate;
+                  oldInherited = this.inheritedType;
+            this.template = this.inheritedType;
+            this.inheritedType = ct.templates.templates[this.inheritedType].extends.inheritedType;
             ct.templates.templates[oldInherited].onCreate.apply(this);
             this.template = oldTemplate;
-            this.inheritedTemplate = oldInherited;
+            this.inheritedType = oldInherited;
         },
         onStep: () => {
             const oldTemplate = this.template,
-                  oldInherited = this.inheritedTemplate;
-            this.template = this.inheritedTemplate;
-            this.inheritedTemplate = ct.templates.templates[this.inheritedTemplate].extends.inheritedTemplate;
+                  oldInherited = this.inheritedType;
+            this.template = this.inheritedType;
+            this.inheritedType = ct.templates.templates[this.inheritedType].extends.inheritedType;
             ct.templates.templates[oldInherited].onStep.apply(this);
             this.template = oldTemplate;
-            this.inheritedTemplate = oldInherited;
+            this.inheritedType = oldInherited;
         },
         onDraw: () => {
             const oldTemplate = this.template,
-                  oldInherited = this.inheritedTemplate;
-            this.template = this.inheritedTemplate;
-            this.inheritedTemplate = ct.templates.templates[this.inheritedTemplate].extends.inheritedTemplate;
+                  oldInherited = this.inheritedType;
+            this.template = this.inheritedType;
+            this.inheritedType = ct.templates.templates[this.inheritedType].extends.inheritedType;
             ct.templates.templates[oldInherited].onDraw.apply(this);
             this.template = oldTemplate;
-            this.inheritedTemplate = oldInherited;
+            this.inheritedType = oldInherited;
         },
         onDestroy: () => {
             const oldTemplate = this.template,
-                  oldInherited = this.inheritedTemplate;
-            this.template = this.inheritedTemplate;
-            this.inheritedTemplate = ct.templates.templates[this.inheritedTemplate].extends.inheritedTemplate;
+                  oldInherited = this.inheritedType;
+            this.template = this.inheritedType;
+            this.inheritedType = ct.templates.templates[this.inheritedType].extends.inheritedType;
             ct.templates.templates[oldInherited].onDestroy.apply(this);
             this.template = oldTemplate;
-            this.inheritedTemplate = oldInherited;
+            this.inheritedType = oldInherited;
         }
     };
 }


### PR DESCRIPTION
Closes #337

**Changes proposed in this pull request:**

- Fix the inherit module by renaming `inheritedTemplate` to `inheritedType`.

**Ping @CosmoMyzrailGorynych**