### PR TITLE
:bug: Big texture support

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -27,7 +27,7 @@
         "javascript-obfuscator": "^2.6.0",
         "js-yaml": "^3.14.0",
         "markdown-it": "12.3.2",
-        "maxrects-packer": "^2.7.1",
+        "maxrects-packer": "^2.7.3",
         "microm": "^0.2.4",
         "monaco-editor": "^0.20.0",
         "monaco-themes": "^0.3.3",
@@ -4876,9 +4876,9 @@
       }
     },
     "node_modules/maxrects-packer": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/maxrects-packer/-/maxrects-packer-2.7.1.tgz",
-      "integrity": "sha512-RtnNTaV6xznnA9YISSE2i8x7sgTosMDJSZOwouyHtSP+uITNXyV7YCsincIZPg/+jKiS22/zjCQ6iT4iX68UcA=="
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/maxrects-packer/-/maxrects-packer-2.7.3.tgz",
+      "integrity": "sha512-bG6qXujJ1QgttZVIH4WDanhoJtvbud/xP/XPyf6A69C9RdA61BM4TomFALCq2nrTa+tARRIBB4LuIFsnUQU2wA=="
     },
     "node_modules/md5": {
       "version": "2.3.0",
@@ -14020,9 +14020,9 @@
       }
     },
     "maxrects-packer": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/maxrects-packer/-/maxrects-packer-2.7.1.tgz",
-      "integrity": "sha512-RtnNTaV6xznnA9YISSE2i8x7sgTosMDJSZOwouyHtSP+uITNXyV7YCsincIZPg/+jKiS22/zjCQ6iT4iX68UcA=="
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/maxrects-packer/-/maxrects-packer-2.7.3.tgz",
+      "integrity": "sha512-bG6qXujJ1QgttZVIH4WDanhoJtvbud/xP/XPyf6A69C9RdA61BM4TomFALCq2nrTa+tARRIBB4LuIFsnUQU2wA=="
     },
     "md5": {
       "version": "2.3.0",

--- a/app/package.json
+++ b/app/package.json
@@ -71,7 +71,7 @@
     "javascript-obfuscator": "^2.6.0",
     "js-yaml": "^3.14.0",
     "markdown-it": "12.3.2",
-    "maxrects-packer": "^2.7.1",
+    "maxrects-packer": "^2.7.3",
     "microm": "^0.2.4",
     "monaco-editor": "^0.20.0",
     "monaco-themes": "^0.3.3",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -317,7 +317,7 @@ const lintI18n = () => require('./node_requires/i18n')(verbose).then(console.log
 const lint = gulp.series(lintJS, lintTags, lintStylus, lintI18n);
 
 const processToPlatformMap = {
-    'darwin-x64': 'darwin',
+    'darwin-x64': 'osx64',
     'win32-x32': 'win32',
     'win32-x64': 'win64',
     'linux-x32': 'linux32',

--- a/src/node_requires/exporter/textures.js
+++ b/src/node_requires/exporter/textures.js
@@ -1,6 +1,8 @@
 const fs = require('fs-extra');
 const glob = require('./../glob');
 
+/* eslint-disable id-blacklist */
+
 const getTextureShape = texture => {
     if (texture.shape === 'rect') {
         return {
@@ -170,31 +172,110 @@ const packerSettings = [atlasWidth, atlasHeight, 0, {
     // allowRotation: true,
     pot: true,
     square: true,
-    // eslint-disable-next-line id-blacklist
     tag: true,
     exclusiveTag: false
 }];
 
+const getPackerFor = (textures, spritedTextures) => {
+    const packer = new Packer(...packerSettings);
+    const animationsByTextures = spritedTextures
+        .map(getTextureFrameCrops);
+    const animations = [].concat(...animationsByTextures);
+    const initAllTags = () => {
+        const result = {};
+        textures.forEach(tex => { result[tex.name] = -1; });
+        return result;
+    };
+
+    if (animations.length) {
+        packer.addArray(animations);
+
+        let failedPacks = [];
+
+        let allTags = initAllTags();
+        packer.bins.forEach((bin, binInd) => bin.rects.forEach(rect => {
+            if (allTags[rect.tag] < 0) allTags[rect.tag] = binInd;
+            else if (allTags[rect.tag] !== binInd
+                && failedPacks.indexOf(rect.tag) < 0) failedPacks.push(rect.tag);
+        }));
+
+        if (failedPacks.length) {
+            // eslint-disable-next-line no-console
+            console.warn("Packing failed...repacking...");
+    
+            packer.reset();
+    
+            packer.addArray(animations.filter(tex => failedPacks.indexOf(tex.tag) > -1));
+            packer.next();
+            packer.addArray(animations.filter(tex => failedPacks.indexOf(tex.tag) < 0));
+    
+            failedPacks = [];
+            allTags = initAllTags();
+            packer.bins.forEach((bin, binInd) => bin.rects.forEach(rect => {
+                if (allTags[rect.tag] < 0) allTags[rect.tag] = binInd;
+                else if (allTags[rect.tag] !== binInd
+                    && failedPacks.indexOf(rect.tag) < 0) failedPacks.push(rect.tag);
+            }));
+            
+            if (failedPacks.length) {
+                // eslint-disable-next-line no-console
+                console.warn("Repacking failed...repacking...");
+            
+                packer.reset();
+    
+                failedPacks.forEach(tag => {
+                    packer.addArray(animations.filter(tex => tex.tag === tag));
+                    packer.next();
+                });
+                packer.addArray(animations.filter(tex => failedPacks.indexOf(tex.tag) < 0));
+            }
+        }
+    }
+
+    return packer;
+};
+
+const isBigTexture = (texture) => {
+    const area = texture.grid[0] * texture.width * texture.grid[1] * texture.height;
+    if (area > atlasWidth * atlasHeight * 0.9) return true;
+    if (texture.width > atlasWidth) return true;
+    if (texture.height > atlasHeight) return true;
+    return false;
+};
+
 const packImages = async (proj, writeDir) => {
-    const spritedTextures = proj.textures.filter(texture => !texture.tiled),
-          tiledTextures = proj.textures.filter(texture => texture.tiled);
+    const textures = proj.textures;
+    const bigTextures = textures.filter(isBigTexture);
+    const spritedTextures = textures.filter(
+        tex => !tex.tiled && bigTextures.indexOf(tex) < 0);
+    const tiledTextures = textures.filter(
+        tex => tex.tiled && bigTextures.indexOf(tex) < 0);
 
     // Write functions will be run in parallel,
     // and this array will block the finalization of the function
     const writePromises = [];
-
-    const packer = new Packer(...packerSettings);
-
-    const animationsByTextures = spritedTextures
-        .map(getTextureFrameCrops);
-    const animations = [].concat(...animationsByTextures);
-    if (animations.length) {
-        packer.addArray(animations);
-    }
+    const packer = getPackerFor(textures, spritedTextures);
 
     // Output all the atlases into JSON and PNG files
     const atlases = [];
     packer.bins.map(drawAtlasFromBin).forEach((atlas, ind) => {
+        writePromises.push(fs.outputJSON(`${writeDir}/img/a${ind}.json`, atlas.json));
+        var atlasBase64 = atlas.canvas.toDataURL().replace(/^data:image\/\w+;base64,/, '');
+        var buf = Buffer.from(atlasBase64, 'base64');
+        writePromises.push(fs.writeFile(`${writeDir}/img/a${ind}.png`, buf));
+        atlases.push(`./img/a${ind}.json`);
+    });
+    bigTextures.forEach((texture, btInd) => {
+        const tw = texture.grid[0] * (texture.width + texture.padding * 2);
+        const th = texture.grid[1] * (texture.height + texture.padding * 2);
+        const bigPacker = new Packer(tw, th, 0, { smart: false });
+        bigPacker.addArray(getTextureFrameCrops(texture));
+        if (bigPacker.bins.length > 1) {
+            // eslint-disable-next-line no-console
+            console.warn("Big packer has failed!");
+        }
+        const ind = packer.bins.length + btInd;
+        const atlas = drawAtlasFromBin(bigPacker.bins[0], ind);
         writePromises.push(fs.outputJSON(`${writeDir}/img/a${ind}.json`, atlas.json));
         var atlasBase64 = atlas.canvas.toDataURL().replace(/^data:image\/\w+;base64,/, '');
         var buf = Buffer.from(atlasBase64, 'base64');

--- a/src/node_requires/exporter/textures.js
+++ b/src/node_requires/exporter/textures.js
@@ -184,11 +184,16 @@ const getPackerFor = (textures, spritedTextures) => {
     const getFailedPacks = () => {
         const failedPacks = [];
         const allTags = {};
-        textures.forEach(tex => { allTags[tex.name] = -1; });
+        textures.forEach(tex => {
+            allTags[tex.name] = -1;
+        });
         packer.bins.forEach((bin, binInd) => bin.rects.forEach(rect => {
-            if (allTags[rect.tag] < 0) allTags[rect.tag] = binInd;
-            else if (allTags[rect.tag] !== binInd
-                && failedPacks.indexOf(rect.tag) < 0) failedPacks.push(rect.tag);
+            if (allTags[rect.tag] < 0) {
+                allTags[rect.tag] = binInd;
+            } else if (allTags[rect.tag] !== binInd &&
+                failedPacks.indexOf(rect.tag) < 0) {
+                failedPacks.push(rect.tag);
+            }
         }));
         return failedPacks;
     };
@@ -200,8 +205,7 @@ const getPackerFor = (textures, spritedTextures) => {
 
         const addToFailedPacks = (newPacks) => {
             failedPacks = failedPacks.concat(newPacks.filter(tag =>
-                failedPacks.indexOf(tag) === -1
-            ));
+                failedPacks.indexOf(tag) === -1));
         };
 
         if (failedPacks.length) {
@@ -212,14 +216,13 @@ const getPackerFor = (textures, spritedTextures) => {
                 const lastFailedPack = failedPacks;
 
                 // eslint-disable-next-line no-console
-                console.warn("Packing failed...repacking...");
+                console.warn('Packing failed...repacking...');
 
                 packer.reset();
                 if (firstRepack) {
                     packer.addArray(animations.filter(tex => lastFailedPack.indexOf(tex.tag) > -1));
                     packer.next();
-                }
-                else {
+                } else {
                     textures.forEach(tex => {
                         const tag = tex.name;
                         if (lastFailedPack.indexOf(tag) > -1) {
@@ -233,7 +236,6 @@ const getPackerFor = (textures, spritedTextures) => {
                 newFailedPacks = getFailedPacks();
                 firstRepack = false;
                 addToFailedPacks(newFailedPacks);
-            
             } while (newFailedPacks.length);
         }
     }
@@ -243,19 +245,23 @@ const getPackerFor = (textures, spritedTextures) => {
 
 const isBigTexture = (texture) => {
     const area = texture.grid[0] * texture.width * texture.grid[1] * texture.height;
-    if (area > atlasWidth * atlasHeight * 0.9) return true;
-    if (texture.width > atlasWidth) return true;
-    if (texture.height > atlasHeight) return true;
+    if (area > atlasWidth * atlasHeight * 0.9) {
+        return true;
+    }
+    if (texture.width > atlasWidth) {
+        return true;
+    }
+    if (texture.height > atlasHeight) {
+        return true;
+    }
     return false;
 };
 
 const packImages = async (proj, writeDir) => {
-    const textures = proj.textures;
+    const {textures} = proj;
     const bigTextures = textures.filter(isBigTexture);
-    const spritedTextures = textures.filter(
-        tex => !tex.tiled && bigTextures.indexOf(tex) < 0);
-    const tiledTextures = textures.filter(
-        tex => tex.tiled && bigTextures.indexOf(tex) < 0);
+    const spritedTextures = textures.filter(tex => !tex.tiled && bigTextures.indexOf(tex) < 0);
+    const tiledTextures = textures.filter(tex => tex.tiled && bigTextures.indexOf(tex) < 0);
 
     // Write functions will be run in parallel,
     // and this array will block the finalization of the function
@@ -266,25 +272,27 @@ const packImages = async (proj, writeDir) => {
     const atlases = [];
     packer.bins.map(drawAtlasFromBin).forEach((atlas, ind) => {
         writePromises.push(fs.outputJSON(`${writeDir}/img/a${ind}.json`, atlas.json));
-        var atlasBase64 = atlas.canvas.toDataURL().replace(/^data:image\/\w+;base64,/, '');
-        var buf = Buffer.from(atlasBase64, 'base64');
+        const atlasBase64 = atlas.canvas.toDataURL().replace(/^data:image\/\w+;base64,/, '');
+        const buf = Buffer.from(atlasBase64, 'base64');
         writePromises.push(fs.writeFile(`${writeDir}/img/a${ind}.png`, buf));
         atlases.push(`./img/a${ind}.json`);
     });
     bigTextures.forEach((texture, btInd) => {
         const tw = texture.grid[0] * (texture.width + texture.padding * 2);
         const th = texture.grid[1] * (texture.height + texture.padding * 2);
-        const bigPacker = new Packer(tw, th, 0, { smart: false });
+        const bigPacker = new Packer(tw, th, 0, {
+            smart: false
+        });
         bigPacker.addArray(getTextureFrameCrops(texture));
         if (bigPacker.bins.length > 1) {
             // eslint-disable-next-line no-console
-            console.warn("Big packer has failed!");
+            console.warn('Big packer has failed!');
         }
         const ind = packer.bins.length + btInd;
         const atlas = drawAtlasFromBin(bigPacker.bins[0], ind);
         writePromises.push(fs.outputJSON(`${writeDir}/img/a${ind}.json`, atlas.json));
-        var atlasBase64 = atlas.canvas.toDataURL().replace(/^data:image\/\w+;base64,/, '');
-        var buf = Buffer.from(atlasBase64, 'base64');
+        const atlasBase64 = atlas.canvas.toDataURL().replace(/^data:image\/\w+;base64,/, '');
+        const buf = Buffer.from(atlasBase64, 'base64');
         writePromises.push(fs.writeFile(`${writeDir}/img/a${ind}.png`, buf));
         atlases.push(`./img/a${ind}.json`);
     });
@@ -306,7 +314,7 @@ const packImages = async (proj, writeDir) => {
         atlas.width = tex.width;
         atlas.height = tex.height;
         atlas.x.drawImage(img, 0, 0);
-        var buf = new Buffer(atlas.toDataURL().replace(/^data:image\/\w+;base64,/, ''), 'base64');
+        const buf = Buffer.from(atlas.toDataURL().replace(/^data:image\/\w+;base64,/, ''), 'base64');
         writePromises.push(fs.writeFile(`${writeDir}/img/t${tiledCounter}.png`, buf));
         tiledCounter++;
     }


### PR DESCRIPTION
Larger textures cause trouble for Ct.js - this is because of limitations in [maxrects-packer](https://github.com/soimy/maxrects-packer).

This is a much less neater pull request than usual and I may return to revisit it. But since it's more a bug than a feature - I wanted to have it posted.

This pull request does several things:

1. Updates `maxrects-packer` to fix an infinite loop bug
2. Corrects the gulpfile for MacOS X
3. If textures are split across files by `maxrects-packer` attempts ~two~ as many repacks as required
4. If textures are so big that they can't fit inside 2048 x 2048 or take up 90% or more of that area, saves them as their own texture at developer's peril (technically anything up to 4096 x 4096 should work on most devices)

~It is possible to fail both repacks and I suppose this is the headache of raster graphics-accelerated games. But this change, or one similar, widens the opportunity for games with biggish textures that would still be performant to get through.~

### Bug presentation

The bug can appear two ways in the present version of Ct.js. Both will only ever occur in projects using biggish texture files.

1. Clicking the "Launch" button results in a continuously spinning loop that never resolves. The same for "Exports" (infinite loop bug).
2. The game launches fine but when it launches the textures on some sprites are wrong given the requested animation frame. Some frames are inaccessible (sprite split across files bug).
