### PR TITLE
:bug: Scale fix for 2.2.0 migration

### DIFF
--- a/src/js/projectMigrationScripts/2.2.0.js
+++ b/src/js/projectMigrationScripts/2.2.0.js
@@ -48,8 +48,8 @@ window.migrationProcess.push({
                 copy.tint = copy.tint ?? 0xffffff;
                 copy.rotation = copy.rotation ?? 0;
                 copy.scale = copy.scale ?? {
-                    x: 1,
-                    y: 1
+                    x: copy.tx || 1,
+                    y: copy.ty || 1
                 };
             }
             for (const bg of room.backgrounds) {


### PR DESCRIPTION
The copies following a 2.2.0 migration don't appear to retain their scaling.

I think this two-line PR fixes that.

I'm not wedded to the approach but the important thing is some fix goes in even if it's not this one.