### PR TITLE
:zap: Do not minify HTML/CSS when not minifying JavaScript

### DIFF
--- a/src/node_requires/exporter/index.ts
+++ b/src/node_requires/exporter/index.ts
@@ -429,17 +429,18 @@ const exportCtProject = async (
     }
 
     // Output minified HTML & CSS
-    const csswring = require('csswring');
-    const htmlMinify = require('html-minifier').minify;
+    const noMinify = currentProject.settings.export.codeModifier === 'none';
+    const csswring = noMinify ? undefined : require('csswring');
+    const htmlMinify = noMinify ? undefined : require('html-minifier').minify;
     await Promise.all([
         fs.writeFile(
             path.join(writeDir, '/index.html'),
-            htmlMinify(html, {
+            noMinify ? html : htmlMinify(html, {
                 removeComments: true,
                 collapseWhitespace: true
             })
         ),
-        fs.writeFile(path.join(writeDir, '/ct.css'), csswring.wring(css).css),
+        fs.writeFile(path.join(writeDir, '/ct.css'), noMinify ? css : csswring.wring(css).css),
         fs.writeFile(path.join(writeDir, '/ct.js'), buffer)
     ]);
 


### PR DESCRIPTION
I haven't actually minified any of my released Ct.js projects, but I noticed Ct.js minfies the HTML/CSS regardless.

This PR disables minification of the HTML/CSS when the user has elected not to minify JavaScript.

There are a bunch of reasons the user may want to review the HTML/CSS including to source Pixi.js from a CDN*, to see where their custom HTML/CSS has been inserted, etc.

_* Potentially CDN-sourced Pixi.js should be an export setting as it's something the user will want repeatedly. But for now I still feel this PR is a positive addition._