### PR TITLE
:sparkles: Adds TypeScript support

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ctjs",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ctjs",
-      "version": "2.2.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@capacitor/cli": "^3.4.0",
@@ -40,6 +40,7 @@
         "pixi.js-legacy": "5.3.11",
         "png2icons": "^2.0.1",
         "serve-handler": "^6.1.3",
+        "sucrase": "^3.25.0",
         "terser": "^5.14.2",
         "ttf2woff": "^2.0.2"
       }
@@ -1283,6 +1284,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
     },
     "node_modules/anymatch": {
       "version": "3.1.2",
@@ -5317,6 +5323,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.1.31",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.31.tgz",
@@ -8096,6 +8112,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/pirates": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
+      "integrity": "sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/pixi-ease": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/pixi-ease/-/pixi-ease-3.0.7.tgz",
@@ -9318,6 +9342,34 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sucrase": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.25.0.tgz",
+      "integrity": "sha512-WxTtwEYXSmZArPGStGBicyRsg5TBEFhT5b7N+tF+zauImP0Acy+CoUK0/byJ8JNPK/5lbpWIVuFagI4+0l85QQ==",
+      "dependencies": {
+        "commander": "^4.0.0",
+        "glob": "7.1.6",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sucrase/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/sumchecker": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
@@ -9462,6 +9514,25 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -9573,6 +9644,11 @@
       "dependencies": {
         "utf8-byte-length": "^1.0.1"
       }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
     },
     "node_modules/ts-node": {
       "version": "10.4.0",
@@ -11354,6 +11430,11 @@
       "requires": {
         "color-convert": "^1.9.0"
       }
+    },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="
     },
     "anymatch": {
       "version": "3.1.2",
@@ -14402,6 +14483,16 @@
         "minimatch": "^3.0.4"
       }
     },
+    "mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "requires": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
     "nanoid": {
       "version": "3.1.31",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.31.tgz",
@@ -16292,6 +16383,11 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
     },
+    "pirates": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
+      "integrity": "sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ=="
+    },
     "pixi-ease": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/pixi-ease/-/pixi-ease-3.0.7.tgz",
@@ -17235,6 +17331,26 @@
         "escape-string-regexp": "^1.0.2"
       }
     },
+    "sucrase": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.25.0.tgz",
+      "integrity": "sha512-WxTtwEYXSmZArPGStGBicyRsg5TBEFhT5b7N+tF+zauImP0Acy+CoUK0/byJ8JNPK/5lbpWIVuFagI4+0l85QQ==",
+      "requires": {
+        "commander": "^4.0.0",
+        "glob": "7.1.6",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
+        }
+      }
+    },
     "sumchecker": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
@@ -17340,6 +17456,22 @@
       "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
       "integrity": "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ=="
     },
+    "thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "requires": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "requires": {
+        "thenify": ">= 3.1.0 < 4"
+      }
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -17429,6 +17561,11 @@
       "requires": {
         "utf8-byte-length": "^1.0.1"
       }
+    },
+    "ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
     },
     "ts-node": {
       "version": "10.4.0",

--- a/app/package.json
+++ b/app/package.json
@@ -84,6 +84,7 @@
     "pixi.js-legacy": "5.3.11",
     "png2icons": "^2.0.1",
     "serve-handler": "^6.1.3",
+    "sucrase": "^3.25.0",
     "terser": "^5.14.2",
     "ttf2woff": "^2.0.2"
   }

--- a/src/node_requires/exporter/index.ts
+++ b/src/node_requires/exporter/index.ts
@@ -386,6 +386,9 @@ const exportCtProject = async (
         }
     }));
 
+    /* TypeScript */
+    buffer = require("sucrase").transform(buffer, {transforms: ["typescript" ]}).code;
+    
     /* HTML & CSS */
     const {substituteHtmlVars} = require('./html');
     const html = substituteHtmlVars(await sources['index.html'], project, injections);

--- a/src/riotTags/project-settings/tabs/script-editor.tag
+++ b/src/riotTags/project-settings/tabs/script-editor.tag
@@ -25,7 +25,7 @@ script-editor.aView
         });
         this.on('mount', () => {
             setTimeout(() => {
-                var editorOptions = {
+                const editorOptions = {
                     language: 'typescript'
                 };
                 this.editor = window.setupCodeEditor(this.refs.editor, editorOptions);

--- a/src/riotTags/project-settings/tabs/script-editor.tag
+++ b/src/riotTags/project-settings/tabs/script-editor.tag
@@ -26,7 +26,7 @@ script-editor.aView
         this.on('mount', () => {
             setTimeout(() => {
                 var editorOptions = {
-                    language: 'javascript'
+                    language: 'typescript'
                 };
                 this.editor = window.setupCodeEditor(this.refs.editor, editorOptions);
                 this.editor.onDidChangeModelContent(() => {

--- a/src/riotTags/project-settings/tabs/script-editor.tag
+++ b/src/riotTags/project-settings/tabs/script-editor.tag
@@ -36,7 +36,13 @@ script-editor.aView
                 window.addEventListener('resize', updateEditorSize);
                 window.signals.on('settingsFocus', updateEditorSizeDeferred);
             }, 0);
-            this.oldName = this.script.name;
+            const glob = require('./data/node_requires/glob');
+            if (glob.scriptTypings[this.script.name]) {
+                for (const lib of glob.scriptTypings[this.script.name]) {
+                    lib.dispose();
+                }
+                delete glob.scriptTypings[this.script.name];
+            }
         });
         this.on('unmount', () => {
             // Manually destroy the editor to free up the memory
@@ -45,12 +51,6 @@ script-editor.aView
 
         this.saveScript = () => {
             const glob = require('./data/node_requires/glob');
-            if (glob.scriptTypings[this.oldName]) {
-                for (const lib of glob.scriptTypings[this.oldName]) {
-                    lib.dispose();
-                }
-                delete glob.scriptTypings[this.oldName];
-            }
             glob.scriptTypings[this.script.name] = [
                 monaco.languages.typescript.javascriptDefaults.addExtraLib(this.script.code),
                 monaco.languages.typescript.typescriptDefaults.addExtraLib(this.script.code)

--- a/src/riotTags/project-settings/tabs/scripts-setttings.tag
+++ b/src/riotTags/project-settings/tabs/scripts-setttings.tag
@@ -28,12 +28,12 @@ scripts-settings
         const glob = require('./data/node_requires/glob');
 
         this.addNewScript = () => {
-            var oldScriptNames = this.currentProject.scripts.map(script => script.name);
-            var newName = 'New Script';
+            const oldScriptNames = this.currentProject.scripts.map(script => script.name);
+            let newName = 'New Script';
             for (let i = 1; oldScriptNames.indexOf(newName) !== -1; i++) {
                 newName = `New Script ${i}`;
             }
-            var script = {
+            const script = {
                 name: newName,
                 code: `/* ${this.voc.newScriptComment} */`
             };

--- a/src/riotTags/project-settings/tabs/scripts-setttings.tag
+++ b/src/riotTags/project-settings/tabs/scripts-setttings.tag
@@ -28,8 +28,13 @@ scripts-settings
         const glob = require('./data/node_requires/glob');
 
         this.addNewScript = () => {
+            var oldScriptNames = this.currentProject.scripts.map(script => script.name);
+            var newName = 'New Script';
+            for (let i = 1; oldScriptNames.indexOf(newName) !== -1; i++) {
+                newName = `New Script ${i}`;
+            }
             var script = {
-                name: 'New Script',
+                name: newName,
                 code: `/* ${this.voc.newScriptComment} */`
             };
             this.currentProject.scripts.push(script);


### PR DESCRIPTION
This relatively simple PR enables TypeScript support for game development. I thought this was a request but can't find the related issue.

There are four parts to it:

1. It adds [sucrase](https://github.com/alangpierce/sucrase) to remove the TypeScript from exports.
2. It converts the script editor to `typescript`
3. It removes the script's typings upon load instead of if there has been a rename
4. It names scripts sequentially "New Script", "New Script 1", "New Script 2", etc.

Explaining each...

1. [sucrase](https://github.com/alangpierce/sucrase) is a fast light-weight cross-compiler. It does TypeScript to ES6, JSX to ES6 and a few others. I was so impressed by the speed, that I removed an initial disable TypeScript option. TypeScript removal happens before the minification as many minifiers require.
2. Making the script editor TypeScript picks up a huge number of additional errors for example `const x = 6; console.log(x.hello)` is valid JavaScript code even though it makes no sense. I suspect the reason why the script editor was made JavaScript is because the editor kept complaining about duplicate function/variable names.
3. The editor kept complaining about duplicate function/variable names because the script being edited was also a library. So Monaco would see `function helloWorld() { ... }` in "New Script 5" and say I already have that function you added it as part of "New Script 5". Removing the "New Script 5" typings on first load of that script in the script editor prevents duplicate complaints - the only downside is the (hopefully brief) moment without typings if users switch to the room editor without first saving their script.
4. The code correctly checks if there exists typings for the script it is loading and only removes them if there does. In the case of "New Script" there are none and Ct.js proceeds normally. But if the user had saved a previous script as "New Script" those typings would be removed upon creation of a new "New Script". Thus uniquely named scripts become more important. This doesn't fix users deliberately naming everything "My Script" and destroying their typings, but it does start them on the right footing by making sure each newly created script has a unique name.

I thought about adding a new example showing off the new features but I'm not sure it's necessary now.