### PR TITLE
:bug: Removes all typings on reset all

### DIFF
--- a/src/riotTags/root-tag.tag
+++ b/src/riotTags/root-tag.tag
@@ -6,6 +6,19 @@ root-tag(class="{pride: localStorage.prideMode === 'on'}")
     script.
         this.projectOpened = false;
         window.signals.on('resetAll', () => {
+            const glob = require('./data/node_requires/glob');
+            for (const script of window.currentProject.scripts) {
+                if (glob.scriptTypings[script.name]) {
+                    const [deleteTypingsTS, deleteTypingsJS] = glob.scriptTypings[script.name];
+                    if (deleteTypingsTS) {
+                        deleteTypingsTS.dispose();
+                    }
+                    if (deleteTypingsJS) {
+                        deleteTypingsJS.dispose();
+                    }
+                }
+            }
+            glob.scriptTypings = {};
             global.currentProject = false;
             require('./data/node_requires/glob').modified = false;
             this.projectOpened = false;


### PR DESCRIPTION
Following on from #369, this removes all typings on a `resetAll` signal.

Such a signal is received when switching projects. The failure to remove typings can lead to complaints about duplicate functions if the two projects contain user scripts with identically named functions.

Ideally one day, I'd like other projects to open in a new window, however for the moment this pull request should suffice.