### PR TITLE
:zap: Tooltip for palette color removal

### DIFF
--- a/app/data/i18n/Brazilian Portuguese.json
+++ b/app/data/i18n/Brazilian Portuguese.json
@@ -132,6 +132,7 @@
     "colorPicker": {
         "current": "Novo",
         "globalPalette": "Paleta Global",
+        "altClick": "",
         "old": "Antigo",
         "projectPalette": "Paleta do Projeto"
     },

--- a/app/data/i18n/Chinese Simplified.json
+++ b/app/data/i18n/Chinese Simplified.json
@@ -132,6 +132,7 @@
     "colorPicker": {
         "current": "新建",
         "globalPalette": "全局调色盘",
+        "altClick": "",
         "old": "旧的",
         "projectPalette": "项目的调色盘"
     },

--- a/app/data/i18n/Comments.json
+++ b/app/data/i18n/Comments.json
@@ -134,6 +134,7 @@
     "colorPicker": {
         "current": "",
         "globalPalette": "",
+        "altClick": "",
         "old": "",
         "projectPalette": ""
     },

--- a/app/data/i18n/Debug.json
+++ b/app/data/i18n/Debug.json
@@ -134,6 +134,7 @@
     "colorPicker": {
         "current": "colorPicker.current",
         "globalPalette": "colorPicker.globalPalette",
+        "altClick": "color.altClick",
         "old": "colorPicker.old",
         "projectPalette": "colorPicker.projectPalette"
     },

--- a/app/data/i18n/Dutch.json
+++ b/app/data/i18n/Dutch.json
@@ -132,6 +132,7 @@
     "colorPicker": {
         "current": "New",
         "globalPalette": "Globaal Palet",
+        "altClick": "",
         "old": "Oud",
         "projectPalette": "Palet van Project"
     },

--- a/app/data/i18n/English.json
+++ b/app/data/i18n/English.json
@@ -159,6 +159,7 @@
     "colorPicker": {
         "current": "New",
         "globalPalette": "Global Palette",
+        "altClick": "Alt-click to delete",
         "old": "Old",
         "projectPalette": "Project's Palette"
     },

--- a/app/data/i18n/French.json
+++ b/app/data/i18n/French.json
@@ -7,6 +7,7 @@
     "colorPicker": {
         "current": "Nouveau",
         "globalPalette": "Palette Globale",
+        "altClick": "",
         "old": "Ancien",
         "projectPalette": "Palette du Projet"
     },

--- a/app/data/i18n/German.json
+++ b/app/data/i18n/German.json
@@ -132,6 +132,7 @@
     "colorPicker": {
         "current": "Neu",
         "globalPalette": "Globale Palette",
+        "altClick": "",
         "old": "Alt",
         "projectPalette": "Projekt Palette"
     },

--- a/app/data/i18n/Japanese.json
+++ b/app/data/i18n/Japanese.json
@@ -155,6 +155,7 @@
     "colorPicker": {
         "current": "新しい",
         "globalPalette": "グローバルのパレット",
+        "altClick": "",
         "old": "古い",
         "projectPalette": "プロジェクトのパレット"
     },

--- a/app/data/i18n/Polish.json
+++ b/app/data/i18n/Polish.json
@@ -132,6 +132,7 @@
     "colorPicker": {
         "current": "Nowy",
         "globalPalette": "Paleta Globalna",
+        "altClick": "",
         "old": "Stary",
         "projectPalette": "Paleta Projektu"
     },

--- a/app/data/i18n/Romanian.json
+++ b/app/data/i18n/Romanian.json
@@ -132,6 +132,7 @@
     "colorPicker": {
         "current": "Nou",
         "globalPalette": "Paletă globală",
+        "altClick": "",
         "old": "Veche",
         "projectPalette": "Paleta proiectului"
     },

--- a/app/data/i18n/Russian.json
+++ b/app/data/i18n/Russian.json
@@ -135,6 +135,7 @@
         "old": "Старый",
         "current": "Новый",
         "globalPalette": "Глобальная палитра",
+        "altClick": "",
         "projectPalette": "Палитра проекта"
     },
     "docsShortcut": {

--- a/app/data/i18n/Spanish.json
+++ b/app/data/i18n/Spanish.json
@@ -132,6 +132,7 @@
     "colorPicker": {
         "current": "Nuevo",
         "globalPalette": "Paleta Global",
+        "altClick": "",
         "old": "Antigua",
         "projectPalette": "Paleta del proyecto"
     },

--- a/app/data/i18n/Turkish.json
+++ b/app/data/i18n/Turkish.json
@@ -159,6 +159,7 @@
     "colorPicker": {
         "current": "Yeni",
         "globalPalette": "Küresel Palet",
+        "altClick": "",
         "old": "Eski",
         "projectPalette": "Proje'nin paleti"
     },

--- a/app/data/i18n/Ukranian.json
+++ b/app/data/i18n/Ukranian.json
@@ -133,6 +133,7 @@
         "old": "Старий",
         "current": "Новий",
         "globalPalette": "Глобальна палітра",
+        "altClick": "",
         "projectPalette": "Палітра проекту"
     },
     "docsShortcut": {

--- a/src/riotTags/shared/color-picker.tag
+++ b/src/riotTags/shared/color-picker.tag
@@ -27,12 +27,12 @@ color-picker
         .c6.npt.npl.npb
             h4.nmt {voc.globalPalette}
             .Swatches(ref="globalSwatches")
-                .aSwatch(each="{colr in globalPalette}" style="background-color: {colr};" onclick="{onSwatchClick}")
+                .aSwatch(each="{colr in globalPalette}" style="background-color: {colr};" onclick="{onSwatchClick}" title="{voc.altClick}")
                 button.anAddSwatchButton(onclick="{addAsGlobal}")
                     | +
             h4 {voc.projectPalette}
             .Swatches(ref="localSwatches")
-                .aSwatch(each="{colr in global.currentProject.palette}" style="background-color: {colr};" onclick="{onSwatchClick}")
+                .aSwatch(each="{colr in global.currentProject.palette}" style="background-color: {colr};" onclick="{onSwatchClick}"  title="{voc.altClick}")
                 button.anAddSwatchButton(onclick="{addAsLocal}")
                     | +
         .c6.np
@@ -123,7 +123,7 @@ color-picker
         };
 
         this.onSwatchClick = e => {
-            if (e.ctrlKey) { // deletes a swatch
+            if (e.ctrlKey || e.altKey) { // deletes a swatch
                 if (e.target.parentNode === this.refs.localSwatches) {
                     const ind = global.currentProject.palette.indexOf(e.item.colr);
                     global.currentProject.palette.splice(ind, 1);


### PR DESCRIPTION
This is again mostly a Mac thing because control-click simulates right-click on the Mac (which opens the inspect menu). As a result, Mac users are never able to delete a colour from the colour palette.

This pull request simply adds the alternative to alt-click to delete the colour (which will be much welcomed by Mac users).

It also adds a very discrete browser tooltip so users can discover the functionality. I've cooled a bit on Macs recently as my Intel Mac broke and Apple won't repair it.