### PR TITLE
:zap: Notepad free text support and fixes

### DIFF
--- a/src/riotTags/notepad-panel.tag
+++ b/src/riotTags/notepad-panel.tag
@@ -78,14 +78,24 @@ notepad-panel#notepad.aPanel.dockright(class="{opened: opened}")
         this.getIfDarkTheme = () =>
             localStorage.UItheme === 'Night' || localStorage.UItheme === 'Horizon';
 
+        const notepadProps = {
+            language: 'javascript',
+            quickSuggestions: false,
+            hover: {
+                enabled: false
+            },
+            lightbulb: {
+                enabled: false
+            },
+            // eslint-disable-next-line id-length
+            renderValidationDecorations: 'off',
+            fixedOverflowWidgets: false
+        };
+
         this.on('mount', () => {
             setTimeout(() => {
-                this.notepadlocal = window.setupCodeEditor(this.refs.notepadlocal, {
-                    language: 'typescript'
-                });
-                this.notepadglobal = window.setupCodeEditor(this.refs.notepadglobal, {
-                    language: 'typescript'
-                });
+                this.notepadlocal = window.setupCodeEditor(this.refs.notepadlocal, notepadProps);
+                this.notepadglobal = window.setupCodeEditor(this.refs.notepadglobal, notepadProps);
 
                 this.notepadglobal.setValue(localStorage.notes);
                 this.notepadlocal.setValue(global.currentProject.notes || '');


### PR DESCRIPTION
I haven't used the notepad much but the global notepad was one of the main stumbling points for multi-window editing. This pull request turns off validation decorations but perhaps more importantly turns off fixed overflow widgets. The latter is an important fix for this issue:

https://github.com/microsoft/monaco-editor/issues/2503

Which appears to affect all platforms (although not all instances - I'm guessing it's something to do with the parent display settings or something).

The notepad still highlights as though it's using JavaScript and will still offer suggestions. But free text like "Hello world!" will now have no squiggly lines. The notepad also has a greater threshold for suggestions (again suitable for free text).