### PR TITLE
Fix custom property cloning link issue :bug:

### DIFF
--- a/src/node_requires/roomEditor/entityClasses/Copy.ts
+++ b/src/node_requires/roomEditor/entityClasses/Copy.ts
@@ -53,7 +53,7 @@ class Copy extends PIXI.AnimatedSprite {
         return getTemplateFromId(this.templateId as string).playAnimationOnStart;
     }
 
-    serialize(deepCopy: boolean=false): IRoomCopy {
+    serialize(deepCopy = false): IRoomCopy {
         return {
             x: this.x,
             y: this.y,
@@ -66,7 +66,9 @@ class Copy extends PIXI.AnimatedSprite {
             rotation: this.rotation,
             uid: this.templateId,
             exts: deepCopy ? JSON.parse(JSON.stringify(this.copyExts)) : this.copyExts,
-            customProperties: deepCopy ? JSON.parse(JSON.stringify(this.copyCustomProps)) : this.copyCustomProps
+            customProperties: deepCopy ?
+                JSON.parse(JSON.stringify(this.copyCustomProps)) :
+                this.copyCustomProps
         };
     }
     deserialize(copy: IRoomCopy): void {

--- a/src/node_requires/roomEditor/entityClasses/Copy.ts
+++ b/src/node_requires/roomEditor/entityClasses/Copy.ts
@@ -53,7 +53,7 @@ class Copy extends PIXI.AnimatedSprite {
         return getTemplateFromId(this.templateId as string).playAnimationOnStart;
     }
 
-    serialize(): IRoomCopy {
+    serialize(deepCopy: boolean=false): IRoomCopy {
         return {
             x: this.x,
             y: this.y,
@@ -65,8 +65,8 @@ class Copy extends PIXI.AnimatedSprite {
             },
             rotation: this.rotation,
             uid: this.templateId,
-            exts: this.copyExts,
-            customProperties: this.copyCustomProps
+            exts: deepCopy ? JSON.parse(JSON.stringify(this.copyExts)) : this.copyExts,
+            customProperties: deepCopy ? JSON.parse(JSON.stringify(this.copyCustomProps)) : this.copyCustomProps
         };
     }
     deserialize(copy: IRoomCopy): void {

--- a/src/node_requires/roomEditor/index.ts
+++ b/src/node_requires/roomEditor/index.ts
@@ -219,8 +219,8 @@ class RoomEditor extends PIXI.Application {
             this.addTileLayer(tileLayer);
         }
     }
-    serialize(): void {
-        this.ctRoom.copies = [...this.copies].map(c => c.serialize());
+    serialize(deepCopy: boolean=false): void {
+        this.ctRoom.copies = [...this.copies].map(c => c.serialize(deepCopy));
         this.ctRoom.tiles = this.tileLayers.map(tl => tl.serialize());
         this.ctRoom.backgrounds = this.backgrounds.map(bg => bg.serialize());
         this.ctRoom.lastmod = Number(new Date());

--- a/src/node_requires/roomEditor/interactions/copyPaste.ts
+++ b/src/node_requires/roomEditor/interactions/copyPaste.ts
@@ -19,7 +19,7 @@ export const copy: IRoomEditorInteraction<void> = {
                 if (stuff instanceof Copy) {
                     this.clipboard.add([
                         'copy',
-                        stuff.serialize()
+                        stuff.serialize(true)
                     ]);
                 } else if (stuff instanceof Tile) {
                     this.clipboard.add([


### PR DESCRIPTION
Closes #387 .

**Changes proposed in this pull request:**
The Copy.ts file now deep clones the customProperties property to prevent reference cloning. This is also done to exts since it is also a reference. To prevent serialize() from always deep cloning for performance reasons, a new parameter is introduced whether to deep clone the two objects (defaults to false).

@CosmoMyzrailGorynych 
