### PR TITLE
:zap: Exclude blank textures from export and retain shape

### DIFF
--- a/app/data/ct.release/res.js
+++ b/app/data/ct.release/res.js
@@ -264,9 +264,9 @@
          * @note Formatted as a non-jsdoc comment as it requires a better ts declaration
          * than the auto-generated one
          */
-        getTextureShape(name) {
+        getTextureShape(name, template) {
             if (name === -1) {
-                return {};
+                return template.shape || {};
             }
             if (!(name in ct.res.textures)) {
                 throw new Error(`Attempt to get a shape of a non-existent texture ${name}`);

--- a/app/data/ct.release/templates.js
+++ b/app/data/ct.release/templates.js
@@ -122,9 +122,9 @@ const Copy = (function Copy() {
                     onDestroy: t.onDestroy
                 });
                 if (exts && exts.tex !== void 0) {
-                    this.shape = ct.res.getTextureShape(exts.tex || -1);
+                    this.shape = ct.res.getTextureShape(exts.tex || -1, t);
                 } else {
-                    this.shape = ct.res.getTextureShape(t.texture || -1);
+                    this.shape = ct.res.getTextureShape(t.texture || -1, t);
                 }
                 if (exts && exts.depth !== void 0) {
                     this.depth = exts.depth;

--- a/src/node_requires/exporter/templates.ts
+++ b/src/node_requires/exporter/templates.ts
@@ -2,7 +2,7 @@ const {getTextureFromId} = require('../resources/textures');
 const {getUnwrappedExtends} = require('./utils');
 
 import {flattenGroups} from './groups';
-
+import {getTextureShape} from './textures';
 import {getBaseScripts} from './scriptableProcessor';
 
 interface IBlankTexture {
@@ -11,6 +11,7 @@ interface IBlankTexture {
     anchorY: number;
     height: number;
     width: number;
+    shape: any;
 }
 
 const getTextureInfo = (blankTextures: IBlankTexture[], template: ITemplate) => {
@@ -19,7 +20,8 @@ const getTextureInfo = (blankTextures: IBlankTexture[], template: ITemplate) => 
         return `anchorX: ${blankTexture.anchorX},
         anchorY: ${blankTexture.anchorY},
         height: ${blankTexture.height},
-        width: ${blankTexture.width},`;
+        width: ${blankTexture.width},
+        shape: ${JSON.stringify(blankTexture.shape)},`;
     } else if (template.texture !== -1) {
         return `texture: "${getTextureFromId(template.texture).name}",`;
     }
@@ -40,7 +42,8 @@ const stringifyTemplates = function (proj: IProject): IScriptablesFragment {
             anchorX: tex.axis[0] / tex.width,
             anchorY: tex.axis[1] / tex.height,
             height: tex.height,
-            width: tex.width
+            width: tex.width,
+            shape: getTextureShape(tex)
         }));
 
     for (const k in proj.templates) {

--- a/src/node_requires/exporter/textures.ts
+++ b/src/node_requires/exporter/textures.ts
@@ -348,7 +348,7 @@ export const packImages = async (
     production: boolean
 ): Promise<exportedTextureData> => {
     const {textures: allTextures} = proj;
-    const textures = allTextures.filter(tex => !tex.isBlank)
+    const textures = allTextures.filter(tex => !tex.isBlank);
     const bigTextures = textures.filter(isBigTexture);
     const spritedTextures = textures.filter(tex => !tex.tiled && bigTextures.indexOf(tex) < 0);
     const tiledTextures = textures.filter(tex => tex.tiled && bigTextures.indexOf(tex) < 0);

--- a/src/node_requires/exporter/textures.ts
+++ b/src/node_requires/exporter/textures.ts
@@ -29,7 +29,7 @@ type packerBin = {
 
 /* eslint-disable id-blacklist */
 
-const getTextureShape = (texture: ITexture): textureShape => {
+export const getTextureShape = (texture: ITexture): textureShape => {
     if (texture.shape === 'rect') {
         return {
             type: 'rect',
@@ -347,7 +347,8 @@ export const packImages = async (
     writeDir: string,
     production: boolean
 ): Promise<exportedTextureData> => {
-    const {textures} = proj;
+    const {textures: allTextures} = proj;
+    const textures = allTextures.filter(tex => !tex.isBlank)
     const bigTextures = textures.filter(isBigTexture);
     const spritedTextures = textures.filter(tex => !tex.tiled && bigTextures.indexOf(tex) < 0);
     const tiledTextures = textures.filter(tex => tex.tiled && bigTextures.indexOf(tex) < 0);

--- a/src/node_requires/resources/templates/ITemplate.d.ts
+++ b/src/node_requires/resources/templates/ITemplate.d.ts
@@ -8,6 +8,7 @@ interface ITemplate extends IScriptable {
     playAnimationOnStart: boolean,
     loopAnimation: boolean,
     animationFPS: number,
+    shape?: any,
     extends: {
         [key: string]: unknown
     }

--- a/src/node_requires/resources/templates/ITemplate.d.ts
+++ b/src/node_requires/resources/templates/ITemplate.d.ts
@@ -8,7 +8,6 @@ interface ITemplate extends IScriptable {
     playAnimationOnStart: boolean,
     loopAnimation: boolean,
     animationFPS: number,
-    shape?: any,
     extends: {
         [key: string]: unknown
     }


### PR DESCRIPTION
I love my blank textures but unfortunately there were a few bugs in the first implementation. This pull request:

* Excludes the blank textures from export (part of the whole point of them)
* Retains the shape of the blank texture so it can be used as a button

`PIXI.Graphics` considers (0, 0) to be the anchor point of a blank texture. This is confusing **however** `PIXI.Graphics` considers (0, 0) to be the anchor point of a non-blank texture - so the behaviour is consistent.

This is another pull request in my attempts to cherry pick the most mature fixes from [this branch](https://github.com/markmehere/ct-js/tree/various-fixes-updated) and generate pull requests for them.