### PR TITLE
:zap: Introduces ct.keyboard.permitDefault and ct.pointer.permitDefault

### DIFF
--- a/app/data/ct.libs/keyboard/README.md
+++ b/app/data/ct.libs/keyboard/README.md
@@ -33,3 +33,7 @@ Tells if a `ctrl` button is held now.
 ## ct.keyboard.clear();
 
 Resets all the parameters listed above.
+
+## ct.keyboard.permitDefault
+
+When you call `ct.keyboard.permitDefault = true`, tells `ct.keyboard` not to execute `e.preventDefault()`. Useful if you have a HTML text box that must respond to the standard browser events.

--- a/app/data/ct.libs/keyboard/index.js
+++ b/app/data/ct.libs/keyboard/index.js
@@ -40,7 +40,9 @@
                     ct.keyboard.string = '';
                 }
             }
-            e.preventDefault();
+            if (!ct.permitDefault) {
+                e.preventDefault();
+            }
         },
         onUp(e) {
             ct.keyboard.shift = e.shiftKey;
@@ -51,7 +53,9 @@
             } else {
                 setKey('Unknown', 0);
             }
-            e.preventDefault();
+            if (!ct.permitDefault) {
+                e.preventDefault();
+            }
         }
     };
 

--- a/app/data/ct.libs/keyboard/index.js
+++ b/app/data/ct.libs/keyboard/index.js
@@ -11,6 +11,7 @@
         alt: false,
         shift: false,
         ctrl: false,
+        permitDefault: false,
         clear() {
             delete ct.keyboard.lastKey;
             delete ct.keyboard.lastCode;
@@ -40,7 +41,7 @@
                     ct.keyboard.string = '';
                 }
             }
-            if (!ct.permitDefault) {
+            if (!ct.keyboard.permitDefault) {
                 e.preventDefault();
             }
         },
@@ -53,7 +54,7 @@
             } else {
                 setKey('Unknown', 0);
             }
-            if (!ct.permitDefault) {
+            if (!ct.keyboard.permitDefault) {
                 e.preventDefault();
             }
         }

--- a/app/data/ct.libs/keyboard/types.d.ts
+++ b/app/data/ct.libs/keyboard/types.d.ts
@@ -37,6 +37,12 @@ declare namespace ct {
         var ctrl: boolean;
 
         /**
+         * Temporarily suspend e.preventDefault() calls. For example, to allow for a HTML text
+         * box to be used.
+         */
+        var permitDefault: boolean;
+
+        /**
          * Resets all the `ct.keyboard` parameters.
          */
         function clear(): void;

--- a/app/data/ct.libs/mouse/README.md
+++ b/app/data/ct.libs/mouse/README.md
@@ -54,6 +54,10 @@ Returns `true` if the mouse hovers over a given `copy` in UI coordinates. This d
 ## `ct.mouse.hide()`, `ct.mouse.show()`
 Change the visibility of the mouse cursor.
 
+## `ct.mouse.permitDefault`
+
+When you call `ct.mouse.permitDefault = true`, tells `ct.mouse` not to execute `e.preventDefault()`. Useful if you have HTML controls that must respond to the standard browser events or wish to show the context menu.
+
 ## Codes for Actions
 
 * `Left`;

--- a/app/data/ct.libs/mouse/index.js
+++ b/app/data/ct.libs/mouse/index.js
@@ -93,7 +93,9 @@
         ct.mouse.down = true;
         ct.mouse.button = e.button;
         window.focus();
-        e.preventDefault();
+        if (!ct.permitDefault) {
+            e.preventDefault();
+        }
     };
     ct.mouse.listenerUp = function listenerUp(e) {
         setKey(buttonMap[e.button] || buttonMap.unknown, 0);
@@ -101,10 +103,14 @@
         ct.mouse.down = false;
         ct.mouse.button = e.button;
         window.focus();
-        e.preventDefault();
+        if (!ct.permitDefault) {
+            e.preventDefault();
+        }
     };
     ct.mouse.listenerContextMenu = function listenerContextMenu(e) {
-        e.preventDefault();
+        if (!ct.permitDefault) {
+            e.preventDefault();
+        }
     };
     ct.mouse.listenerWheel = function listenerWheel(e) {
         setKey('Wheel', ((e.wheelDelta || -e.detail) < 0) ? -1 : 1);

--- a/app/data/ct.libs/mouse/index.js
+++ b/app/data/ct.libs/mouse/index.js
@@ -27,6 +27,7 @@
         pressed: false,
         down: false,
         released: false,
+        permitDefault: false,
         button: 0,
         hovers(copy) {
             if (!copy.shape) {
@@ -93,7 +94,7 @@
         ct.mouse.down = true;
         ct.mouse.button = e.button;
         window.focus();
-        if (!ct.permitDefault) {
+        if (!ct.mouse.permitDefault) {
             e.preventDefault();
         }
     };
@@ -103,12 +104,12 @@
         ct.mouse.down = false;
         ct.mouse.button = e.button;
         window.focus();
-        if (!ct.permitDefault) {
+        if (!ct.mouse.permitDefault) {
             e.preventDefault();
         }
     };
     ct.mouse.listenerContextMenu = function listenerContextMenu(e) {
-        if (!ct.permitDefault) {
+        if (!ct.mouse.permitDefault) {
             e.preventDefault();
         }
     };

--- a/app/data/ct.libs/mouse/types.d.ts
+++ b/app/data/ct.libs/mouse/types.d.ts
@@ -19,6 +19,11 @@ declare namespace ct {
          * a cursor inside the drawing canvas.
          */
         var inside: boolean;
+        /**
+         * Temporarily suspend e.preventDefault() calls. For example, to allow for a HTML text
+         * box to be used.
+         */
+        var permitDefault: boolean;
         /** Returns `true` if the mouse hovers over a given `copy`.
          * This does **not** take scaling and rotation into account,
          * as well as polygonal shapes (as they are hollow).

--- a/app/data/ct.libs/pointer/docs/General use.md
+++ b/app/data/ct.libs/pointer/docs/General use.md
@@ -36,3 +36,5 @@ For newcomers, you will probably start with the following:
   if (ct.pointer.collides(this, undefined, true)) {
       ct.sound.spawn('UI_Blep');
   }
+
+* `ct.pointer.permitDefault` can be set to `true` (e.g. `ct.pointer.permitDefault = true`) to tell `ct.pointer` not to execute `e.preventDefault()`. This is useful if you have HTML controls that must respond to the standard browser events or wish to show the context menu. If the setting "Do not cancel standard browser events" is checked this value will be ignored.

--- a/app/data/ct.libs/pointer/index.js
+++ b/app/data/ct.libs/pointer/index.js
@@ -112,7 +112,7 @@
         }
     };
     var handleMove = function (e) {
-        if (![/*%preventdefault%*/][0] && !ct.permitDefault) {
+        if (![/*%preventdefault%*/][0] && !ct.pointer.permitDefault) {
             e.preventDefault();
         }
         let pointerHover = ct.pointer.hover.find(p => p.id === e.pointerId);
@@ -136,7 +136,7 @@
         }
     };
     var handleDown = function (e) {
-        if (![/*%preventdefault%*/][0] && !ct.permitDefault) {
+        if (![/*%preventdefault%*/][0] && !ct.pointer.permitDefault) {
             e.preventDefault();
         }
         ct.pointer.type = e.pointerType;
@@ -148,7 +148,7 @@
         }
     };
     var handleUp = function (e) {
-        if (![/*%preventdefault%*/][0] && !ct.permitDefault) {
+        if (![/*%preventdefault%*/][0] && !ct.pointer.permitDefault) {
             e.preventDefault();
         }
         const pointer = ct.pointer.down.find(p => p.id === e.pointerId);
@@ -162,7 +162,7 @@
     };
     var handleWheel = function handleWheel(e) {
         setKey('Wheel', ((e.wheelDelta || -e.detail) < 0) ? -1 : 1);
-        if (![/*%preventdefault%*/][0] && !ct.permitDefault) {
+        if (![/*%preventdefault%*/][0] && !ct.pointer.permitDefault) {
             e.preventDefault();
         }
     };
@@ -263,6 +263,7 @@
         twist: 0,
         width: 1,
         height: 1,
+        permitDefault: false,
         type: null,
         clear() {
             ct.pointer.down.length = 0;

--- a/app/data/ct.libs/pointer/index.js
+++ b/app/data/ct.libs/pointer/index.js
@@ -236,7 +236,7 @@
                 passive: false
             });
             document.addEventListener('contextmenu', e => {
-                if (![/*%preventdefault%*/][0] && !ct.permitDefault) {
+                if (![/*%preventdefault%*/][0] && !ct.pointer.permitDefault) {
                     e.preventDefault();
                 }
             });

--- a/app/data/ct.libs/pointer/index.js
+++ b/app/data/ct.libs/pointer/index.js
@@ -112,7 +112,7 @@
         }
     };
     var handleMove = function (e) {
-        if (![/*%preventdefault%*/][0]) {
+        if (![/*%preventdefault%*/][0] && !ct.permitDefault) {
             e.preventDefault();
         }
         let pointerHover = ct.pointer.hover.find(p => p.id === e.pointerId);
@@ -136,7 +136,7 @@
         }
     };
     var handleDown = function (e) {
-        if (![/*%preventdefault%*/][0]) {
+        if (![/*%preventdefault%*/][0] && !ct.permitDefault) {
             e.preventDefault();
         }
         ct.pointer.type = e.pointerType;
@@ -148,7 +148,7 @@
         }
     };
     var handleUp = function (e) {
-        if (![/*%preventdefault%*/][0]) {
+        if (![/*%preventdefault%*/][0] && !ct.permitDefault) {
             e.preventDefault();
         }
         const pointer = ct.pointer.down.find(p => p.id === e.pointerId);
@@ -162,7 +162,7 @@
     };
     var handleWheel = function handleWheel(e) {
         setKey('Wheel', ((e.wheelDelta || -e.detail) < 0) ? -1 : 1);
-        if (![/*%preventdefault%*/][0]) {
+        if (![/*%preventdefault%*/][0] && !ct.permitDefault) {
             e.preventDefault();
         }
     };
@@ -236,7 +236,7 @@
                 passive: false
             });
             document.addEventListener('contextmenu', e => {
-                if (![/*%preventdefault%*/][0]) {
+                if (![/*%preventdefault%*/][0] && !ct.permitDefault) {
                     e.preventDefault();
                 }
             });

--- a/app/data/ct.libs/pointer/types.d.ts
+++ b/app/data/ct.libs/pointer/types.d.ts
@@ -223,6 +223,11 @@ declare namespace ct {
             checkReleased?: boolean
         ): false | IPointer;
         /**
+         * Temporarily suspend e.preventDefault() calls. For example, to allow for a HTML text
+         * box to be used.
+         */
+        var permitDefault: boolean;
+        /**
          * Either returns the pointer that is currently hovering over the passed copy that exists
          * in gameplay coordinates, or returns `false` if there is no such pointers.
          */

--- a/app/data/ct.libs/touch/README.md
+++ b/app/data/ct.libs/touch/README.md
@@ -89,3 +89,7 @@ this.angle += ct.u.radToDeg(ct.actions.Rotate.value);
 You can read `ct.touch.enabled` to get whether touch events are supported on the current machine.
 
 **Beware:** because of tons of hybrid devices like laptops with touchscreens and some subsequent technical limitations, `ct.touch` can only determine this **after a user touches the screen**. That means that `ct.touch.enabled` will be `false` at startup till the first interaction, even on smartphones, so please design you UI and gameplay stuff around this limitation.
+
+## `ct.touch.permitDefault`
+
+When you call `ct.touch.permitDefault = true`, tells `ct.touch` not to execute `e.preventDefault()`. Useful if you have HTML controls that must respond to the standard browser events or wish to show the context menu. If the setting "Do not cancel standard browser events" is checked this value will be ignored.

--- a/app/data/ct.libs/touch/index.js
+++ b/app/data/ct.libs/touch/index.js
@@ -51,7 +51,7 @@
         return -1;
     };
     var handleStart = function (e) {
-        if (![/*%preventdefault%*/][0]) {
+        if (![/*%preventdefault%*/][0] && !ct.permitDefault) {
             e.preventDefault();
         }
         for (let i = 0, l = e.changedTouches.length; i < l; i++) {
@@ -65,7 +65,7 @@
         countTouches();
     };
     var handleMove = function (e) {
-        if (![/*%preventdefault%*/][0]) {
+        if (![/*%preventdefault%*/][0] && !ct.permitDefault) {
             e.preventDefault();
         }
         for (let i = 0, l = e.changedTouches.length; i < l; i++) {
@@ -85,7 +85,7 @@
         }
     };
     var handleRelease = function (e) {
-        if (![/*%preventdefault%*/][0]) {
+        if (![/*%preventdefault%*/][0] && !ct.permitDefault) {
             e.preventDefault();
         }
         var touches = e.changedTouches;

--- a/app/data/ct.libs/touch/index.js
+++ b/app/data/ct.libs/touch/index.js
@@ -51,7 +51,7 @@
         return -1;
     };
     var handleStart = function (e) {
-        if (![/*%preventdefault%*/][0] && !ct.permitDefault) {
+        if (![/*%preventdefault%*/][0] && !ct.touch.permitDefault) {
             e.preventDefault();
         }
         for (let i = 0, l = e.changedTouches.length; i < l; i++) {
@@ -65,7 +65,7 @@
         countTouches();
     };
     var handleMove = function (e) {
-        if (![/*%preventdefault%*/][0] && !ct.permitDefault) {
+        if (![/*%preventdefault%*/][0] && !ct.touch.permitDefault) {
             e.preventDefault();
         }
         for (let i = 0, l = e.changedTouches.length; i < l; i++) {
@@ -85,7 +85,7 @@
         }
     };
     var handleRelease = function (e) {
-        if (![/*%preventdefault%*/][0] && !ct.permitDefault) {
+        if (![/*%preventdefault%*/][0] && !ct.touch.permitDefault) {
             e.preventDefault();
         }
         var touches = e.changedTouches;

--- a/app/data/ct.libs/touch/index.js
+++ b/app/data/ct.libs/touch/index.js
@@ -158,6 +158,7 @@
         yui: 0,
         xuiprev: 0,
         yuiprev: 0,
+        permitDefault: false,
         clear() {
             ct.touch.events.length = 0;
             ct.touch.clearReleased();

--- a/app/data/ct.libs/touch/types.d.ts
+++ b/app/data/ct.libs/touch/types.d.ts
@@ -63,6 +63,12 @@ declare namespace ct {
 
         var events: ITouch[];
 
+        /**
+         * Temporarily suspend e.preventDefault() calls. For example, to allow for a HTML text
+         * box to be used.
+         */
+        var permitDefault: boolean;
+
         function getById(id: number): ITouch | false;
 
         /**

--- a/app/data/ct.release/main.js
+++ b/app/data/ct.release/main.js
@@ -30,11 +30,6 @@ const ct = {
     stack: [],
     fps: [/*@maxfps@*/][0] || 60,
     /**
-     * Temporarily suspend e.preventDefault() calls. For example, to allow for a HTML text
-     * box to be used.
-     */
-    permitDefault: false,
-    /**
      * A measure of how long a frame took time to draw, usually equal to 1 and larger on lags.
      * For example, if it is equal to 2, it means that the previous frame took twice as much time
      * compared to expected FPS rate.

--- a/app/data/ct.release/main.js
+++ b/app/data/ct.release/main.js
@@ -30,6 +30,11 @@ const ct = {
     stack: [],
     fps: [/*@maxfps@*/][0] || 60,
     /**
+     * Temporarily suspend e.preventDefault() calls. For example, to allow for a HTML text
+     * box to be used.
+     */
+    permitDefault: false,
+    /**
      * A measure of how long a frame took time to draw, usually equal to 1 and larger on lags.
      * For example, if it is equal to 2, it means that the previous frame took twice as much time
      * compared to expected FPS rate.


### PR DESCRIPTION
Often I only need the user to be able to use the default browser actions on one or two room.

For example to scroll through the achievements or to enter a high score.

This pull request introduces a boolean `ct.permitDefault` that can be set to `true` when calls to `e.preventDefault();` should be suspended. The feature is implemented across `ct.touch`, `ct.mouse`, `ct.pointer` and `ct.keyboard`.

Incidentally (but unrelated to the PR) `ct.pointer` does not work on iOS, so please keep `ct.touch` around until Safari sorts this out.

This is another pull request in my attempts to cherry pick the most mature fixes from [this branch](https://github.com/markmehere/ct-js/tree/various-fixes-updated) and generate pull requests for them.