### PR TITLE
:zap: Adds alpha setting for vkeys

### DIFF
--- a/app/data/ct.libs/pointer/README.md
+++ b/app/data/ct.libs/pointer/README.md
@@ -1,3 +1,3 @@
 This module abstracts the Web Pointer API, allowing you to track any type of pointers: mouses, touch events, tablet pens, or anything else that is supported by one's system.
 
-The module replaces `ct.mouse` and `ct.touch` from previous versions, uniting their API and adding new features, like pressure and pen position reading.
+The module replaces `ct.mouse` and `ct.touch` from previous versions, uniting their API and adding new features, like pressure and pen position reading. `ct.touch` may still be required on iOS.

--- a/app/data/ct.libs/vkeys/DOCS.md
+++ b/app/data/ct.libs/vkeys/DOCS.md
@@ -9,7 +9,8 @@ Options include:
 * `texHover` — the texture for a hover state. If not provided, it will use `texNormal` instead.
 * `texActive` — the texture for a pressed state. If not provided, it will use `texNormal` instead.
 * `x` and `y` — number that position a button in the room. If a function is provided, it will update the position every frame.
-* `depth` — the depth value;
+* `depth` — the depth value.
+* `alpha` - the alpha value between 0 (transparent) and 1 (opaque).
 * `container` — the parent of the created button. It defaults to the current room.
 
 Example of a button that self-aligns in the viewport:
@@ -21,6 +22,7 @@ var keyLeft = ct.vkeys.button({
     texHover: 'Key_Active',
     x: () => ct.camera.right - 130,
     y: () => ct.camera.bottom - 130,
+    alpha: 0.7,
     depth: 14000
 });
 ```
@@ -35,7 +37,8 @@ Options include:
 * `tex` — the texture for the trackpad. Its collision shape is used to calculate joystick's values and to position the trackball.
 * `trackballTex` — the texture for the trackball.
 * `x` and `y` — number that position a button in the room. If a function is provided, it will update the position every frame.
-* `depth` — the depth value;
+* `depth` — the depth value.
+* `alpha` - the alpha value between 0 (transparent) and 1 (opaque).
 * `container` — the parent of the created button. It defaults to the current room.
 
 Example of a joystick that self-aligns in the viewport:

--- a/app/data/ct.libs/vkeys/index.js
+++ b/app/data/ct.libs/vkeys/index.js
@@ -4,6 +4,7 @@
             var opts = ct.u.ext({
                 key: 'Vk1',
                 depth: 100,
+                alpha: 1,
                 texNormal: -1,
                 x: 128,
                 y: 128,
@@ -21,6 +22,7 @@
             var opts = ct.u.ext({
                 key: 'Vjoy1',
                 depth: 100,
+                alpha: 1,
                 tex: -1,
                 trackballTex: -1,
                 x: 128,

--- a/app/data/ct.libs/vkeys/injections/templates.js
+++ b/app/data/ct.libs/vkeys/injections/templates.js
@@ -50,6 +50,7 @@
         onCreate: function () {
             this.tex = this.opts.texNormal;
             this.depth = this.opts.depth;
+            this.alpha = this.opts.alpha;
         }
     };
 
@@ -57,6 +58,7 @@
         onCreate: function () {
             this.tex = this.opts.tex;
             this.depth = this.opts.depth;
+            this.alpha = this.opts.alpha;
             this.down = false;
             this.trackball = new PIXI.Sprite(ct.res.getTexture(this.opts.trackballTex, 0));
             this.addChild(this.trackball);

--- a/app/data/ct.libs/vkeys/types.d.ts
+++ b/app/data/ct.libs/vkeys/types.d.ts
@@ -12,6 +12,8 @@ interface IVkeysButtonOptions {
     texHover?: string | -1;
     /** The texture for a pressed state. If not provided, it will use `texNormal` instead. */
     texActive?: string | -1;
+    /** The alpha of the button. Defaults to 1 (fully opaque). */
+    alpha?: number;
     /** A number that position a button in the room. If a function is provided, it will update the position every frame. */
     x: number | VkeysReturnNumber;
     /** A number that position a button in the room. If a function is provided, it will update the position every frame. */
@@ -31,6 +33,8 @@ interface IVkeysJoystickOptions {
     key: VKeysJoystickCode;
     /** The texture for the trackpad. Its collision shape is used to calculate joystick's values and to position the trackball. */
     tex: string | -1;
+    /** The alpha of the button. Defaults to 1 (fully opaque). */
+    alpha?: number;
     /** The texture for the trackball. */
     trackballTex: string | -1;
     /** A number that position a button in the room. If a function is provided, it will update the position every frame. */


### PR DESCRIPTION
This adds an alpha setting for `vkeys` allowing for translucent `vkeys`.

I would also like a `scale` parameter but that will require some adjustment to the `ct.place` code.

The PR also includes a brief warning about the iOS `ct.pointer` issues lest it drive another dev crazy.

This is another pull request in my attempts to cherry pick the most mature fixes from [this branch](https://github.com/markmehere/ct-js/tree/various-fixes-updated) and generate pull requests for them.