### PR TITLE
:bug: Allow textures to be set to -1

### DIFF
--- a/app/data/ct.release/res.js
+++ b/app/data/ct.release/res.js
@@ -266,7 +266,7 @@
          */
         getTextureShape(name, template) {
             if (name === -1) {
-                return template.shape || {};
+                return template ? template.shape || {} : {};
             }
             if (!(name in ct.res.textures)) {
                 throw new Error(`Attempt to get a shape of a non-existent texture ${name}`);


### PR DESCRIPTION
Unfortunately the `ct.transition` catmod contains the line:

```
this.tex = -1;
```

I had not foreseen such code and, without this fix, such code causes my code to crash due to `template` being undefined.

This PR fixes that bug. I have not used [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) for compatibility.