### PR TITLE
🐛 New room previewer

### DIFF
--- a/src/node_requires/roomEditor/entityClasses/Background.ts
+++ b/src/node_requires/roomEditor/entityClasses/Background.ts
@@ -1,9 +1,10 @@
 import {getPixiTexture} from '../../resources/textures';
 import {RoomEditor} from '..';
+import { RoomEditorPreview } from '../previewer';
 
 class Background extends PIXI.TilingSprite {
     bgTexture: assetRef;
-    editor: RoomEditor;
+    editor: RoomEditor | RoomEditorPreview;
     shiftX = 0;
     shiftY = 0;
     parallaxX = 1;
@@ -14,7 +15,7 @@ class Background extends PIXI.TilingSprite {
     simulatedMovedY = 0;
     repeat: canvasPatternRepeat = 'repeat';
 
-    constructor(bgInfo: IRoomBackground, editor: RoomEditor) {
+    constructor(bgInfo: IRoomBackground, editor: RoomEditor | RoomEditorPreview) {
         super(getPixiTexture(bgInfo.texture, 0, true));
         this.anchor.x = this.anchor.y = 0;
         this.editor = editor;
@@ -25,7 +26,7 @@ class Background extends PIXI.TilingSprite {
         const ind = this.editor.backgrounds.indexOf(this);
         if (ind !== -1) {
             this.editor.backgrounds.splice(ind, 1);
-            this.editor.riotEditor.refs.backgroundsEditor?.update();
+            this.editor.riotEditor?.refs.backgroundsEditor?.update();
         }
         super.destroy();
     }
@@ -36,13 +37,13 @@ class Background extends PIXI.TilingSprite {
         }
         this.editor.backgrounds.splice(ind, 1);
         this.parent.removeChild(this);
-        this.editor.riotEditor.refs.backgroundsEditor.update();
+        this.editor.riotEditor?.refs.backgroundsEditor.update();
         return this;
     }
     restore(): this {
         this.editor.backgrounds.push(this);
         this.editor.room.addChild(this);
-        this.editor.riotEditor.refs.backgroundsEditor.update();
+        this.editor.riotEditor?.refs.backgroundsEditor.update();
         return this;
     }
 

--- a/src/node_requires/roomEditor/entityClasses/Copy.ts
+++ b/src/node_requires/roomEditor/entityClasses/Copy.ts
@@ -1,6 +1,7 @@
 import {RoomEditor} from '..';
 import {getPixiTexture, getTemplateFromId} from '../../resources/templates';
 import {getTexturePivot} from '../../resources/textures';
+import { RoomEditorPreview } from '../previewer';
 
 /**
  * @notice This class automatically adds and removes itself from editor's copy list
@@ -11,11 +12,11 @@ class Copy extends PIXI.AnimatedSprite {
     copyCustomProps: Record<string, unknown>;
     cachedTemplate: ITemplate;
     isGhost: boolean;
-    editor: RoomEditor;
+    editor: RoomEditor | RoomEditorPreview;
     autoUpdate: boolean;
     update: (deltaTime: number) => void;
 
-    constructor(copyInfo: IRoomCopy, editor: RoomEditor, isGhost?: boolean) {
+    constructor(copyInfo: IRoomCopy, editor: RoomEditor | RoomEditorPreview, isGhost?: boolean) {
         super(getPixiTexture(copyInfo.uid));
         this.editor = editor;
         this.templateId = copyInfo.uid;

--- a/src/node_requires/roomEditor/entityClasses/Tile.ts
+++ b/src/node_requires/roomEditor/entityClasses/Tile.ts
@@ -1,6 +1,7 @@
 import {getPixiTexture, getTexturePivot} from '../../resources/textures';
 import {RoomEditor} from '..';
 import {TileLayer} from './TileLayer';
+import { RoomEditorPreview } from '../previewer';
 
 /**
  * @notice This class automatically adds and removes itself from editor's tile list
@@ -9,10 +10,10 @@ class Tile extends PIXI.Sprite {
     tileTexture: assetRef;
     tileFrame: number;
     parent: TileLayer | null;
-    editor: RoomEditor;
+    editor: RoomEditor | RoomEditorPreview;
     isGhost: boolean;
 
-    constructor(tileInfo: ITileTemplate, editor: RoomEditor, isGhost?: boolean) {
+    constructor(tileInfo: ITileTemplate, editor: RoomEditor | RoomEditorPreview, isGhost?: boolean) {
         super(getPixiTexture(tileInfo.texture, tileInfo.frame, false));
         this.editor = editor;
         this.deserialize(tileInfo);

--- a/src/node_requires/roomEditor/entityClasses/TileLayer.ts
+++ b/src/node_requires/roomEditor/entityClasses/TileLayer.ts
@@ -1,5 +1,6 @@
 import {Tile} from './Tile';
 import {RoomEditor} from '..';
+import { RoomEditorPreview } from '../previewer';
 
 let idCounter = 0;
 
@@ -10,9 +11,9 @@ export const resetCounter = (): void => {
 export class TileLayer extends PIXI.Container {
     extends: Record<string, unknown>;
     children: Tile[];
-    editor: RoomEditor;
+    editor: RoomEditor | RoomEditorPreview;
     id: number;
-    constructor(tileLayer: ITileLayerTemplate, editor: RoomEditor) {
+    constructor(tileLayer: ITileLayerTemplate, editor: RoomEditor | RoomEditorPreview) {
         super();
         this.editor = editor;
         this.id = idCounter++;
@@ -42,7 +43,7 @@ export class TileLayer extends PIXI.Container {
         }
         this.parent.removeChild(this);
         if (writeToHistory) {
-            this.editor.history.pushChange({
+            this.editor.history?.pushChange({
                 type: 'tileLayerDeletion',
                 deleted: this
             });

--- a/src/node_requires/roomEditor/index.ts
+++ b/src/node_requires/roomEditor/index.ts
@@ -17,6 +17,7 @@ import {getPixiSwatch} from './../themes';
 import {defaultTextStyle, recolorFilters, eraseCursor, toPrecision, snapToDiagonalGrid, snapToRectangularGrid} from './common';
 import {getTemplateFromId} from '../resources/templates';
 import {ease, Easing} from 'node_modules/pixi-ease';
+import { RoomEditorPreview } from './previewer';
 
 
 const roomEditorDefaults = {
@@ -727,24 +728,28 @@ class RoomEditor extends PIXI.Application {
      * as it repositions the room.
      */
     getSplashScreen(big: boolean): HTMLCanvasElement {
+        return RoomEditor.getRoomPreview(this.ctRoom, big);
+    }
+
+    static getRoomPreview(room: IRoom, big: boolean): HTMLCanvasElement {
         const w = big ? 340 : 64,
               h = big ? 256 : 64;
         const renderTexture = PIXI.RenderTexture.create({
             width: w,
             height: h
         });
-        this.overlays.visible = false;
-        this.transformer.visible = false;
-        this.pointerCoords.visible = false;
-        this.clicktrap.width = w;
-        this.clicktrap.height = h;
-        this.clicktrap.alpha = 1;
-        this.clicktrap.tint = this.renderer.backgroundColor;
-        this.room.scale.set(Math.min(w / this.ctRoom.width, h / this.ctRoom.height));
-        this.room.x = (w - this.ctRoom.width * this.room.scale.x) / 2;
-        this.room.y = (h - this.ctRoom.height * this.room.scale.y) / 2;
-        this.renderer.render(this.stage, renderTexture);
-        return this.renderer.extract.canvas(renderTexture);
+        const canvas = document.createElement('canvas');
+        canvas.width = w;
+        canvas.height = h;
+        const pixelart = Boolean(currentProject.settings.rendering.pixelatedrender);
+        const scale = Math.min(w / room.width, h / room.height);
+        const preview = new RoomEditorPreview({ view: canvas }, room, pixelart, {
+            x: (w - room.width * scale) / 2,
+            y: (h - room.height * scale) / 2,
+            scale
+        });
+        preview.renderer.render(preview.stage, renderTexture);
+        return preview.renderer.extract.canvas(renderTexture);
     }
 }
 

--- a/src/node_requires/roomEditor/previewer.ts
+++ b/src/node_requires/roomEditor/previewer.ts
@@ -1,0 +1,128 @@
+import {History} from './history';
+
+import {Copy} from './entityClasses/Copy';
+import {Tile} from './entityClasses/Tile';
+import {TileLayer} from './entityClasses/TileLayer';
+import {Background} from './entityClasses/Background';
+import {Viewport} from './entityClasses/Viewport';
+
+import {IRoomEditorRiotTag} from './IRoomEditorRiotTag';
+
+const roomEditorDefaults = {
+    width: 10,
+    height: 10,
+    autoDensity: true,
+    transparent: false,
+    sharedLoader: true,
+    sharedTicker: false,
+    resolution: devicePixelRatio,
+    antialias: true,
+    preserveDrawingBuffer: true
+};
+
+interface RoomSettings {
+    x: number;
+    y: number;
+    scale: number;
+}
+
+export class RoomEditorPreview extends PIXI.Application {
+    ctRoom: IRoom;
+    camera = new PIXI.Container();
+    room = new PIXI.Container();
+
+    copies = new Set<Copy>();
+    tiles = new Set<Tile>();
+    backgrounds: Background[] = [];
+    viewports = new Set<Viewport>();
+    tileLayers: TileLayer[] = [];
+
+    primaryViewport: Viewport;
+    riotEditor: IRoomEditorRiotTag;
+    history: History;
+    updateMouseoverHint = (text: string, newRef: unknown) => {};
+    mouseoverOut = (ref: unknown) => {};
+
+    constructor(opts: unknown, room: IRoom, pixelart: boolean, roomSettings: RoomSettings) {
+        super(Object.assign({}, roomEditorDefaults, opts, {
+            roundPixels: pixelart,
+            width: room.width,
+            height: room.height
+        }));
+
+        this.ctRoom = room;
+        this.room.sortableChildren = true;
+        this.room.scale.set(roomSettings.scale);
+        this.room.x = roomSettings.x;
+        this.room.y = roomSettings.y;
+
+        this.camera.x = room.width / 2;
+        this.camera.y = room.height / 2;
+        this.primaryViewport = {
+            width: room.width,
+            height: room.height
+        } as Viewport;
+        this.stage.addChild(this.camera);
+
+        this.stage.addChild(this.room);
+        this.deserialize(room);
+
+        this.stage.interactive = false;
+        
+    }
+
+    destroy(removeView: boolean, stageOptions: {
+        children?: boolean;
+        texture?: boolean;
+        baseTexture?: boolean;
+    }): void {
+        super.destroy(removeView, stageOptions);
+    }
+
+    deserialize(room: IRoom): void {
+        this.renderer.backgroundColor = PIXI.utils.string2hex(room.backgroundColor);
+        for (const bg of room.backgrounds) {
+            this.addBackground(bg);
+        }
+        for (const copy of room.copies) {
+            try {
+                const pixiCopy = new Copy(copy, this);
+                this.room.addChild(pixiCopy);
+            } catch (e) {
+                console.error(e);
+                window.alertify.error(e.message);
+            }
+        }
+        for (const tileLayer of room.tiles) {
+            this.addTileLayer(tileLayer);
+        }
+    }
+
+    addTileLayer(tileLayer: ITileLayerTemplate | TileLayer, writeToHistory?: boolean): TileLayer {
+        const pixiTileLayer = tileLayer instanceof TileLayer ?
+            tileLayer :
+            new TileLayer(tileLayer, this);
+        this.room.addChild(pixiTileLayer);
+        this.tileLayers.push(pixiTileLayer);
+        this.tileLayers.sort((a, b) => b.zIndex - a.zIndex);
+        if (pixiTileLayer.children) {
+            for (const tile of pixiTileLayer.children) {
+                this.tiles.add(tile);
+            }
+        }
+        if (writeToHistory) {
+            this.history.pushChange({
+                type: 'tileLayerCreation',
+                created: pixiTileLayer
+            });
+        }
+        return pixiTileLayer;
+    }
+
+    addBackground(bgTemplate: IRoomBackground): Background {
+        const bg = new Background(bgTemplate, this);
+        this.backgrounds.push(bg);
+        this.room.addChild(bg);
+        return bg;
+    }
+}


### PR DESCRIPTION
This introduces a new room previewer as one of three pull requests to upgrade the preview engine of Ct.js.

The new room previewer can be called at anytime to generate a room preview - it isn't restricted to just before the room editor closes. This is useful because a later pull request aims regenerate previews automatically on project open. This in turn is useful because it means the frequently changing previews can be added to the `.gitignore` file.

The new room previewer also fixes some background/zoom-level bugs you can see in the below screenshot:

![room-issues](https://github.com/ct-js/ct-js/assets/52765023/88fe3428-5de3-4533-9634-c0dd57de8bfe)

And subsequently fixed (note even the third room is not repeating the background which is an improvement):

![room-fixes](https://github.com/ct-js/ct-js/assets/52765023/754d7b3b-560e-4bf8-ae8f-f0d4fcbca754)

It does mean if you change `RoomEditor` and want to see your changes in the preview you'll need to also change `RoomEditorPreview` but I think overall this will be worth it. The previewer should also 🤞 be compatible with the new unified asset fix (which I looked at but didn't extend because it was still a work in progress).