### PR TITLE
📝 Fix type definitions for ct.backgrounds & gamepad module

### DIFF
--- a/app/data/ct.libs/gamepad/types.d.ts
+++ b/app/data/ct.libs/gamepad/types.d.ts
@@ -1,0 +1,73 @@
+declare namespace ct {
+  /**
+   * Use gamepads in the actions system
+   */
+  namespace gamepad {
+    /**
+     * Represents an event handler that runs when a gamepad is connected or disconnected
+     * @param event - Run when connected or disconnected
+     * @param eventHandler - Function to run
+     */
+    function on(event: "connected" | "disconnected", eventHandler:Function): void;
+    /**
+     * An array of Gamepad objects, one for each connected gamepad
+     */
+    var list: Array<any>;
+    /**
+     * Returns whether the button is pressed (1) or not (0)
+     * @param code - Button code, can be "Button1", "Button2", "Button3", "Button4", "L1", "R1", "L2", "R2", "Select", "Start", "L3", "R3", "Up", "Down", "Left", "Right", or "Any"
+     */
+    function getButton(
+      code: 
+        "Button1" | 
+        "Button2" |
+        "Button3" |
+        "Button4" |
+        "L1" |
+        "R1" |
+        "L2" |
+        "R2" |
+        "Select" |
+        "Start" |
+        "L3" |
+        "R3" |
+        "Up" |
+        "Down" |
+        "Left" |
+        "Right" |
+        "Any"
+    ): number;
+    /**
+     * Gets the position of a joystick, from -1 to 1, with 0 being its resting position
+     * @param code - Joystick axis, one of "LStickX", "LStickY", "RStickX", or "RStickY"
+     */
+    function getAxis(
+      code:
+        "LStickX" |
+        "LStickY" |
+        "RStickX" |
+        "RStickY"
+    ): number;
+    /**
+     * The last button pressed
+     */
+    var lastButton:
+      "Button1" | 
+      "Button2" |
+      "Button3" |
+      "Button4" |
+      "L1" |
+      "R1" |
+      "L2" |
+      "R2" |
+      "Select" |
+      "Start" |
+      "L3" |
+      "R3" |
+      "Up" |
+      "Down" |
+      "Left" |
+      "Right" |
+      "Any";
+  }
+}

--- a/app/data/ct.release/backgrounds.js
+++ b/app/data/ct.release/backgrounds.js
@@ -107,8 +107,15 @@ class Background extends PIXI.TilingSprite {
  */
 ct.backgrounds = {
     Background,
+    /**
+     * An object that contains all the backgrounds of the current room. 
+     */
     list: {},
     /**
+     * @param texName - Name of a texture to use as a background
+     * @param [frame] - The index of a frame to use. Defaults to 0
+     * @param [depth] - The depth to place the background at. Defaults to 0
+     * @param [container] - Where to put the background. Defaults to current room, can be a room or other pixi container.
      * @returns {Background} The created background
      */
     add(texName, frame = 0, depth = 0, container = ct.room) {

--- a/app/data/ct.release/backgrounds.js
+++ b/app/data/ct.release/backgrounds.js
@@ -109,6 +109,7 @@ ct.backgrounds = {
     Background,
     /**
      * An object that contains all the backgrounds of the current room. 
+     * @type {Object.<string,Array<Background>>}
      */
     list: {},
     /**


### PR DESCRIPTION
**Changes proposed in this pull request:**

- Updated type definitions in `app/data/ct.release/backgrounds.js`
- Wrote new type definition file for the gamepad catmod, at `app/data/ct.libs/gamepad/types.d.ts`

**Ping @CosmoMyzrailGorynych**
