### PR TITLE
:bug: Context menu fixes

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -27,6 +27,7 @@
         "html2pug": "^4.0.0",
         "javascript-obfuscator": "^4.0.2",
         "js-yaml": "^3.14.0",
+        "lodash": "^4.17.21",
         "markdown-it": "12.3.2",
         "maxrects-packer": "^2.7.3",
         "microm": "^0.2.4",

--- a/app/package.json
+++ b/app/package.json
@@ -70,6 +70,7 @@
     "html2pug": "^4.0.0",
     "javascript-obfuscator": "^4.0.2",
     "js-yaml": "^3.14.0",
+    "lodash": "^4.17.21",
     "markdown-it": "12.3.2",
     "maxrects-packer": "^2.7.3",
     "microm": "^0.2.4",

--- a/src/node_requires/resources/rooms/index.ts
+++ b/src/node_requires/resources/rooms/index.ts
@@ -1,5 +1,5 @@
 import {RoomPreviewer} from '../preview/room';
-import {getOfType} from '..';
+import {IAssetContextItem, getOfType} from '..';
 
 const getDefaultRoom = require('./defaultRoom').get;
 const fs = require('fs-extra');
@@ -15,7 +15,7 @@ const createNewRoom = async function createNewRoom(name: string): Promise<IRoom>
     return room;
 };
 
-export const getStartingRoom = (): IRoom => {
+const getStartingRoom = (): IRoom => {
     const rooms = getOfType('room');
     if (global.currentProject.startroom && global.currentProject.startroom !== -1) {
         return rooms.find(room => room.uid === global.currentProject.startroom);
@@ -24,16 +24,34 @@ export const getStartingRoom = (): IRoom => {
 };
 
 const getThumbnail = RoomPreviewer.getClassic;
-export const areThumbnailsIcons = false;
+const areThumbnailsIcons = false;
 
-export const removeAsset = (room: IRoom): void => {
+const removeAsset = (room: IRoom): void => {
     if (global.currentProject.startroom === room.uid) {
         global.currentProject.startroom = -1;
     }
 };
 
+const assetContextMenuItems: IAssetContextItem[] = [
+    {
+        icon: 'play',
+        vocPath: 'rooms.makeStarting',
+        action: async (
+            asset: ISkeleton,
+            collection: folderEntries,
+            folder: IAssetFolder
+        ) => {
+            global.currentProject.startroom = asset.uid;
+        }
+    }
+];
+
 export {
     createNewRoom,
+    getStartingRoom,
+    areThumbnailsIcons,
+    removeAsset,
+    assetContextMenuItems,
     createNewRoom as createAsset,
     getThumbnail
 };

--- a/src/riotTags/shared/asset-browser.tag
+++ b/src/riotTags/shared/asset-browser.tag
@@ -183,6 +183,7 @@ asset-browser.flexfix(class="{opts.namespace} {opts.class} {compact: opts.compac
         this.mixin(require('./data/node_requires/riotMixins/niceTime').default);
         this.sort = 'type';
         this.sortReverse = false;
+        this.lodash = require('lodash');
 
         const resources = require('data/node_requires/resources');
         this.assetTypes = this.opts.assettypes ? this.opts.assettypes.split(',') : ['all'];
@@ -536,6 +537,7 @@ asset-browser.flexfix(class="{opts.namespace} {opts.class} {compact: opts.compac
             this.contextMenuAsset = item;
             const contextActions = resources.getContextActions(item);
             if (contextActions.length > 0) {
+                contextActions.forEach(contextAction => contextAction.label = this.lodash.get(this.vocFull, contextAction.vocPath, ' '));
                 contextActions.push({
                     type: 'separator'
                 });

--- a/src/riotTags/shared/asset-browser.tag
+++ b/src/riotTags/shared/asset-browser.tag
@@ -496,7 +496,7 @@ asset-browser.flexfix(class="{opts.namespace} {opts.class} {compact: opts.compac
                     .defaultValue(this.contextMenuAsset.name)
                     .prompt(this.vocGlob.newName)
                 if (reply.inputValue && reply.inputValue.trim() !== '' && reply.buttonClicked !== 'cancel') {
-                    this.contextMenuAsset.name = e.inputValue.trim();
+                    this.contextMenuAsset.name = reply.inputValue.trim();
                     this.update();
                 }
             }


### PR DESCRIPTION
Three fixes to the `pixi-v7` branch:

* Rename fix for asset browser (a simple typo correction)
* Resolve `vocPath` to fix context labels (this is done using the existing `lodash` version)
* Restore set starting room menu item

`gulp lint` is reporting a heroic `74836 problems (74177 errors, 659 warnings)` so I wasn't able to lint it.

**Ping @CosmoMyzrailGorynych**
