### PR TITLE
🐛 Text: Work even if style is undefined

### DIFF
--- a/src/node_requires/roomEditor/entityClasses/Copy.ts
+++ b/src/node_requires/roomEditor/entityClasses/Copy.ts
@@ -236,7 +236,7 @@ class Copy extends PIXI.Container {
         if (cts.wordWrapWidth) {
             this.text.style.wordWrapWidth = Number(cts.wordWrapWidth);
             this.text.style.wordWrap = true;
-        } else {
+        } else if (this.cachedTemplate.textStyle) {
             this.text.style.wordWrap = this.cachedTemplate.textStyle !== -1 &&
                 getById('style', this.cachedTemplate.textStyle).font.wrap;
         }


### PR DESCRIPTION
Closes/Checks a single checkbox of `#448` (`UI: anchor buttons work but don't get their active class applied.`) 

**Changes proposed in this pull request:**
- In `src/node_requires/roomEditor/entityClasses/Copy.ts`
  - Only run `getById()` with `this.cachedTemplate.textStyle` when `this.cachedTemplate.textStyle` is defined
 
**Problems this solves**
Because `getById()` threw an error if `textStyle` was undefined, the UI anchor buttons would not apply their `active` class.

Yay

**Ping @CosmoMyzrailGorynych**
