### PR TITLE
:bug: Room.merge() preserves scale and other properties for copies

### DIFF
--- a/app/data/ct.release/rooms.js
+++ b/app/data/ct.release/rooms.js
@@ -286,7 +286,11 @@ Room.roomId = 0;
                 const c = ct.templates.copyIntoRoom(t.template, t.x, t.y, target, {
                     tx: t.tx || 1,
                     ty: t.ty || 1,
-                    tr: t.tr || 0
+                    tr: t.tr || 0,
+                    scaleX: t.scale?.x,
+                    scaleY: t.scale?.y,
+                    rotation: t.rotation,
+                    alpha: t.opacity
                 });
                 generated.copies.push(c);
             }


### PR DESCRIPTION

Closes (unfiled)

**Changes proposed in this pull request:**

Room.merge() should keep the scale etc of the objects it copies.
