### PR TITLE
📝 Drop ct. prefix in catmod docs

### DIFF
--- a/app/data/ct.libs/fs/DOCS.md
+++ b/app/data/ct.libs/fs/DOCS.md
@@ -1,55 +1,55 @@
-## `ct.fs.forceLocal: boolean`
+## `fs.forceLocal: boolean`
 
 When set to `true`, any operations towards files outside the game's save directory will fail.
 Set to `true` by default.
 
-## `ct.fs.isAvailable: boolean`
+## `fs.isAvailable: boolean`
 When set to `false`, the game is running in a way that disallows access to the filesystem (such as a web release)
 
-## `ct.fs.save(filename: string, data: object|Array): Promise<void>`
+## `fs.save(filename: string, data: object|Array): Promise<void>`
 
 Saves an object/array to a file.
 
-## `ct.fs.load(filename: string): Promise<object|Array>`
+## `fs.load(filename: string): Promise<object|Array>`
 
-Loads an object/array from a file written by `ct.fs.save`.
+Loads an object/array from a file written by `fs.save`.
 
-## `ct.fs.saveText(filename: string, text: string): Promise<void>`
+## `fs.saveText(filename: string, text: string): Promise<void>`
 
 Converts any value to a string and puts it into a file.
 
-## `ct.fs.loadText(filename: string): Promise<string>`
+## `fs.loadText(filename: string): Promise<string>`
 
-Loads a string from a file, previously written by ct.fs.saveText.
+Loads a string from a file, previously written by fs.saveText.
 
-## `ct.fs.makeDir(path: string): Promise<void>`
+## `fs.makeDir(path: string): Promise<void>`
 
 Creates a directory and all the preceding folders, if needed.
 
-## `ct.fs.deleteDir(path: string): Promise<void>`
+## `fs.deleteDir(path: string): Promise<void>`
 
 Removes a given directory with all its contents.
 If an EBUSY, EMFILE, ENFILE, ENOTEMPTY, or EPERM error is encountered,
 it will try again at max 10 times in one second.
 
-## `ct.fs.copy(filename: string, dest: string): Promise<void>`
+## `fs.copy(filename: string, dest: string): Promise<void>`
 Copies a file from one location to another. Does nothing if `filename` and `dest` point to one location.
 
-## `ct.fs.move(filename: string, dest: string): Promise<void>`
+## `fs.move(filename: string, dest: string): Promise<void>`
 Copies a file, then deletes the original. Does nothing if `filename` and `dest` point to one location.
 
-## `ct.fs.listFiles(directory?: string): Promise<Array<string>>`
+## `fs.listFiles(directory?: string): Promise<Array<string>>`
 Returns a promise that resolves into an array of file names in a given directory
 
-## `ct.fs.stat(filename: string): Promise<fs.Stats|boolean>`
+## `fs.stat(filename: string): Promise<fs.Stats|boolean>`
 
 Gets information about a given file.
 
 See https://nodejs.org/api/fs.html#fs_class_fs_stats
 
-**Alias:** `ct.fs.exists`
+**Alias:** `fs.exists`
 
-## `ct.fs.getPath(partial: string): string`
+## `fs.getPath(partial: string): string`
 
 When given a relative path, returns the absolute path equivalent
 to the given one, resolving it relative to the game's save directory.
@@ -57,10 +57,10 @@ to the given one, resolving it relative to the game's save directory.
 No need to use it with `ct.fs` — `getPath` is already used in all its methods.
 The method is useful when working with other libraries, and for debugging.
 
-## `ct.fs.rename(): Promise<void>`
-An alias for `ct.fs.move`. Copies a file from one location to another. Does nothing if `filename` and `dest` point to one location.
+## `fs.rename(): Promise<void>`
+An alias for `fs.move`. Copies a file from one location to another. Does nothing if `filename` and `dest` point to one location.
 
-## `ct.fs.exists(): Promise<fs.Stats|boolean>`
+## `fs.exists(): Promise<fs.Stats|boolean>`
 
-An alias for `ct.fs.stat`. Gets information about a given file.
+An alias for `fs.stat`. Gets information about a given file.
 See https://nodejs.org/api/fs.html#fs_class_fs_stats

--- a/app/data/ct.libs/fs/README.md
+++ b/app/data/ct.libs/fs/README.md
@@ -11,20 +11,20 @@ Within the application directory, ct.js will create a path using the defined Aut
 > **For Example**: If a player with the name `naturecodevoid` was running the game `jettyCat` by `comigo` on Linux, the default directory would be:
  `/home/naturecodevoid/.local/share/comigo/jettyCat`
 
- You can verify this by calling `ct.fs.getPath('')` or by checking the variable `ct.fs.gameFolder`.
+ You can verify this by calling `fs.getPath('')` or by checking the variable `fs.gameFolder`.
 
-It is not recommended, but you can set `ct.fs.gameFolder` to a different directory. This is useful if your meta fields (Author Name, Project Name) have changed, but you wish to preserve user data.
+It is not recommended, but you can set `fs.gameFolder` to a different directory. This is useful if your meta fields (Author Name, Project Name) have changed, but you wish to preserve user data.
 
-Also to note, operations outside of the game folder are not recommended and by default are not allowed, causing an error to appear in the game's console. To allow operations outside of the game folder set `ct.fs.forceLocal` to `false` first.
+Also to note, operations outside of the game folder are not recommended and by default are not allowed, causing an error to appear in the game's console. To allow operations outside of the game folder set `fs.forceLocal` to `false` first.
 
-Every action in `ct.fs` is asynchronous so that a game stays responsive even on heavy loads, and thus you have to use JS Promises. This is not hard, though:
+Every action in `fs` is asynchronous so that a game stays responsive even on heavy loads, and thus you have to use JS Promises. This is not hard, though:
 
 ```js
 // Here we store an object in a JSON file.
-ct.fs.save('savedGame.json', this.gameData)
+fs.save('savedGame.json', this.gameData)
 .then(() => {
     // Here our operation has completed, we can add a feedback now
-    ct.templates.copy('GenericNotification', 20, 20, {
+    templates.copy('GenericNotification', 20, 20, {
         message: 'Game saved!'
     });
 });
@@ -37,25 +37,25 @@ this.kill = true;
 
 ## Determining if ct.fs is supported
 
-Ct.fs is designed for use on desktop devices, and its methods won't work in browsers. You can check for `ct.fs.isAvailable` to determine what you can do:
+Ct.fs is designed for use on desktop devices, and its methods won't work in browsers. You can check for `fs.isAvailable` to determine what you can do:
 
 ```js
-if (ct.fs.isAvailable) {
+if (fs.isAvailable) {
     // All is well, we have an access to the filesystem.
-    ct.fs.save('saveData.cat', ct.game); // your file should not necessarily have `json` extension, btw ;)
+    fs.save('saveData.cat', game); // your file should not necessarily have `json` extension, btw ;)
 } else {
     // File system is not available; we can add a fallback to a browser's local storage instead.
     // see https://docs.ctjs.rocks/localstorage.html
-    localStorage.saveData = JSON.stringify(ct.game);
+    localStorage.saveData = JSON.stringify(game);
 }
 ```
 
 ## Hints
 
-* If you store all your game progression info in one object, you can make your whole save/load system in about 2-3 lines of code with `ct.fs.save` and `ct.fs.load`.
+* If you store all your game progression info in one object, you can make your whole save/load system in about 2-3 lines of code with `fs.save` and `fs.load`.
 * You can't simply store copies inside a save file, but you can serialize them by using a bit of js magic:
   ```js
-  const hero = ct.templates.list['Hero'][0];
+  const hero = templates.list['Hero'][0];
   const saveData = {
       hero: {
           x: hero.x,
@@ -63,23 +63,23 @@ if (ct.fs.isAvailable) {
       },
       enemies: []
   };
-  for (const enemy of ct.templates.list['Enemy']) {
+  for (const enemy of templates.list['Enemy']) {
       saveData.enemies.push({
           x: enemy.x,
           y: enemy.y,
           hp: enemy.hp
       });
   }
-  ct.fs.save('savegame.json', saveData);
+  fs.save('savegame.json', saveData);
 
   // Later…
 
-  ct.fs.load('savegame.json', saveData => {
-      const hero = ct.templates.list['Hero'][0];
+  fs.load('savegame.json', saveData => {
+      const hero = templates.list['Hero'][0];
       hero.x = saveData.hero.x;
       hero.y = saveData.hero.y;
       for (const enemy of saveData.enemies) {
-          ct.templates.copy('Enemy', enemy.x, enemy.y);
+          templates.copy('Enemy', enemy.x, enemy.y);
       }
   });
   ```

--- a/app/data/ct.libs/fs/types.d.ts
+++ b/app/data/ct.libs/fs/types.d.ts
@@ -26,88 +26,82 @@ interface IStats {
     isSymbolicLink(): boolean;
 }
 
-declare namespace ct {
-    /** A module that provides a uniform API for storing and loading data for your desktop games. */
-    namespace fs {
+/** A module that provides a uniform API for storing and loading data for your desktop games. */
+declare namespace fs {
+    /**
+     * When set to `true`, any operations towards files outside the game's save directory will fail.
+     * Set to `true` by default.
+     */
+    var forceLocal: boolean;
 
-        /**
-         * When set to `true`, any operations towards files outside the game's save directory will fail.
-         * Set to `true` by default.
-         */
-        var forceLocal: boolean;
+    /**
+     * When set to `false`, the game is running in a way that disallows access to the filesystem (such as a web release)
+     */
+    var isAvailable: boolean;
 
-        /**
-         * When set to `false`, the game is running in a way that disallows access to the filesystem (such as a web release)
-         */
-        var isAvailable: boolean;
+    /**
+     * The base location for application data. Not for normal usage.
+     */
+    var gameFolder: string;
 
-        /**
-         * The base location for application data. Not for normal usage.
-         */
-        var gameFolder: string;
+    /** Saves an object/array to a file. */
+    function save(filename: string, data: object|any[]): Promise<void>;
 
-        /** Saves an object/array to a file. */
-        function save(filename: string, data: object|any[]): Promise<void>;
+    /** Loads an object/array from a file written by `ct.fs.save`. */
+    function load(filename: string): Promise<object|any[]>;
 
-        /** Loads an object/array from a file written by `ct.fs.save`. */
-        function load(filename: string): Promise<object|any[]>;
+    /** Converts any value to a string and puts it into a file. */
+    function saveText(filename: string, text: string): Promise<void>;
 
-        /** Converts any value to a string and puts it into a file. */
-        function saveText(filename: string, text: string): Promise<void>;
+    /** Loads a string from a file, previously written by ct.fs.saveText. */
+    function loadText(filename: string): Promise<string>;
 
-        /** Loads a string from a file, previously written by ct.fs.saveText. */
-        function loadText(filename: string): Promise<string>;
+    /** Creates a directory and all the preceding folders, if needed. */
+    function makeDir(path: string): Promise<void>;
 
-        /** Creates a directory and all the preceding folders, if needed. */
-        function makeDir(path: string): Promise<void>;
+    /**
+     * Removes a given directory with all its contents.
+     * If an EBUSY, EMFILE, ENFILE, ENOTEMPTY, or EPERM error is encountered,
+     * it will try again at max 10 times in one second.
+     */
+    function deleteDir(path: string): Promise<void>;
 
-        /**
-         * Removes a given directory with all its contents.
-         * If an EBUSY, EMFILE, ENFILE, ENOTEMPTY, or EPERM error is encountered,
-         * it will try again at max 10 times in one second.
-         */
-        function deleteDir(path: string): Promise<void>;
+    /** Copies a file from one location to another. Does nothing if `filename` and `dest` point to one location.*/
+    function copy(filename: string, dest: string): Promise<void>;
 
-        /** Copies a file from one location to another. Does nothing if `filename` and `dest` point to one location.*/
-        function copy(filename: string, dest: string): Promise<void>;
+    /** Copies a file, then deletes the original. Does nothing if `filename` and `dest` point to one location. */
+    function move(filename: string, dest: string): Promise<void>;
 
-        /** Copies a file, then deletes the original. Does nothing if `filename` and `dest` point to one location. */
-        function move(filename: string, dest: string): Promise<void>;
+    /** Returns a promise that resolves into an array of file names in a given directory */
+    function listFiles(directory?: string): Promise<void>;
 
-        /** Returns a promise that resolves into an array of file names in a given directory */
-        function listFiles(directory?: string): Promise<void>;
+    /**
+     * Gets information about a given file.
+     * @see https://nodejs.org/api/fs.html#fs_class_fs_stats
+     */
+    function stat(filename: string): Promise<IStats|boolean>;
 
-        /**
-         * Gets information about a given file.
-         * @see https://nodejs.org/api/fs.html#fs_class_fs_stats
-         */
-        function stat(filename: string): Promise<IStats|boolean>;
+    /**
+     * When given a relative path, returns the absolute path equivalent
+     * to the given one, resolving it relative to the game's save directory.
+     *
+     * No need to use it with `ct.fs` — `getPath` is already used in all its methods.
+     * The method is useful when working with other libraries, and for debugging.
+     */
+    function getPath(partial: string): string;
 
-        /**
-         * When given a relative path, returns the absolute path equivalent
-         * to the given one, resolving it relative to the game's save directory.
-         *
-         * No need to use it with `ct.fs` — `getPath` is already used in all its methods.
-         * The method is useful when working with other libraries, and for debugging.
-         */
-        function getPath(partial: string): string;
+    /** An alias for `ct.fs.move`. Copies a file from one location to another. Does nothing if `filename` and `dest` point to one location. */
+    function rename(): Promise<void>;
 
-        /** An alias for `ct.fs.move`. Copies a file from one location to another. Does nothing if `filename` and `dest` point to one location. */
-        function rename(): Promise<void>;
-
-        /**
-         * An alias for `ct.fs.stat`. Gets information about a given file.
-         * @see https://nodejs.org/api/fs.html#fs_class_fs_stats
-         */
-        function exists(): Promise<IStats|boolean>;
-
-    }
+    /**
+     * An alias for `ct.fs.stat`. Gets information about a given file.
+     * @see https://nodejs.org/api/fs.html#fs_class_fs_stats
+     */
+    function exists(): Promise<IStats|boolean>;
 }
 
-declare namespace ct {
-    namespace fs {
-        /** Removes a given file */
-        var _delete: function(string): Promise<void>;
-        export {_delete as delete};
-    }
+declare namespace fs {
+    /** Removes a given file */
+    var _delete: function(string): Promise<void>;
+    export {_delete as delete};
 }

--- a/app/data/ct.libs/pointer/docs/General use.md
+++ b/app/data/ct.libs/pointer/docs/General use.md
@@ -7,33 +7,33 @@ For those who worked with `ct.mouse` and/or `ct.touch`, `ct.pointer` is a module
 For newcomers, you will probably start with the following:
 
 * Use the Actions system to read global pointer input. For example, you can have an action `Jump` that is triggered by pointer's primary button, so your character can jump when you click with your mouse or press with your finger.
-* To position objects under the cursor, use `ct.pointer.x` and `ct.pointer.y` for gameplay elements and `ct.pointer.xui` and `ct.pointer.yui` for UI elements.
+* To position objects under the cursor, use `pointer.x` and `pointer.y` for gameplay elements and `pointer.xui` and `pointer.yui` for UI elements.
 * To get if a player is pressing your button, in its On Step event use the following code:
   ```js
-  if (ct.pointer.collides(this)) {
+  if (pointer.collides(this)) {
       // Do something! :D
       // The button is currently pressed
   }
   ```
   This code can also be expanded to account for hover and idle state:
   ```js
-  if (ct.pointer.collides(this)) {
+  if (pointer.collides(this)) {
       // Do something! :D
       // The button is currently down
       this.tex = 'Button_Pressed';
-  } else if (ct.pointer.hovers(this)) {
+  } else if (pointer.hovers(this)) {
       this.tex = 'Button_Hover';
   } else {
       this.tex = 'Button_Normal';
   }
   ```
-* `ct.pointer.collides` returns `true` continuously while the pointer's button is held down. If you want to do something once the button is released, use its expanded form that catches only released buttons:
+* `pointer.collides` returns `true` continuously while the pointer's button is held down. If you want to do something once the button is released, use its expanded form that catches only released buttons:
   ```js
   // Second argument is a specific pointer to check against.
   // We pass undefined, meaning that we pass no pointer at all,
   // so it checks against all the pointers.
   // The third argument tells to check against released pointer events.
-  if (ct.pointer.collides(this, undefined, true)) {
-      ct.sound.spawn('UI_Blep');
+  if (pointer.collides(this, undefined, true)) {
+      sound.spawn('UI_Blep');
   }
   ```

--- a/app/data/ct.libs/pointer/docs/Helper methods for buttons.md
+++ b/app/data/ct.libs/pointer/docs/Helper methods for buttons.md
@@ -2,10 +2,10 @@
 
 There are four methods that can tell whether your copy is currently under a cursor (or a pen) and whether it is currently being pressed:
 
-* `ct.pointer.collides(copy, specificPointer, releasedOnly)`
-* `ct.pointer.collidesUi(copy, specificPointer, releasedOnly)`
-* `ct.pointer.hovers(copy, specificPointer)`
-* `ct.pointer.hoversUi(copy, specificPointer)`
+* `pointer.collides(copy, specificPointer, releasedOnly)`
+* `pointer.collidesUi(copy, specificPointer, releasedOnly)`
+* `pointer.hovers(copy, specificPointer)`
+* `pointer.hoversUi(copy, specificPointer)`
 
 `copy` is the copy you want to check against.
 
@@ -16,13 +16,13 @@ There are four methods that can tell whether your copy is currently under a curs
 A generic button code with three states plus an action would look like this:
 
 ```js
-if (ct.pointer.collides(this, undefined, true)) {
-    ct.sound.spawn('UI_Click');
+if (pointer.collides(this, undefined, true)) {
+    sound.spawn('UI_Click');
     // Do something
 }
-if (ct.pointer.collides(this)) {
+if (pointer.collides(this)) {
     this.tex = 'Button_Pressed';
-} else if (ct.pointer.hovers(this)) {
+} else if (pointer.hovers(this)) {
     this.tex = 'Button_Hover';
 } else {
     this.tex = 'Button_Normal';

--- a/app/data/ct.libs/pointer/docs/Pointer Lock mode.md
+++ b/app/data/ct.libs/pointer/docs/Pointer Lock mode.md
@@ -7,30 +7,30 @@ This mode also works with touch and pen events, though its advantages are notice
 The locking mode can be enabled in two ways:
 
 * By turning on the option "Start with locking mode" inside ct.pointer's settings, or
-* By calling `ct.pointer.lock()` any time during your game.
+* By calling `pointer.lock()` any time during your game.
 
-You can disable the locking mode with `ct.pointer.unlock()`.
+You can disable the locking mode with `pointer.unlock()`.
 
 **When the locking mode is on, the following happens:**
 
-* System cursor becomes hidden — you will need to create a copy that follows `ct.pointer.xlocked` and `ct.pointer.ylocked` if you need one.
-* Most of the properties of `ct.pointer`, like `ct.pointer.x`, `ct.pointer.xui`, remain unchanged during the pointer movement, so they should **not** be used.
-* Due to that, `ct.pointer.collides`, `ct.pointer.hovers` and their UI-space versions will always return `false`. Use the `ct.place.occupiedUi` method with your custom cursor if you still need UI events, or disable the locking mode for pause menus and other interfaces.
-  * For touch controls, consider not using the locking mode at all, as locking mode makes little sense with control methods already bound to screen size hardware-wise. You can use `ct.pointer.type` to differ between mouse and touch controls.
+* System cursor becomes hidden — you will need to create a copy that follows `pointer.xlocked` and `pointer.ylocked` if you need one.
+* Most of the properties of `pointer`, like `pointer.x`, `pointer.xui`, remain unchanged during the pointer movement, so they should **not** be used.
+* Due to that, `pointer.collides`, `pointer.hovers` and their UI-space versions will always return `false`. Use the `place.occupiedUi` method with your custom cursor if you still need UI events, or disable the locking mode for pause menus and other interfaces.
+  * For touch controls, consider not using the locking mode at all, as locking mode makes little sense with control methods already bound to screen size hardware-wise. You can use `pointer.type` to differ between mouse and touch controls.
 
 You should use the following properties during the lock mode:
 
-* `ct.pointer.xlocked` and `ct.pointer.ylocked` to read the position of the pointer in UI space. Use `ct.u.uiToGameCoord(ct.pointer.xlocked, ct.pointer.ylocked)` to convert them in gameplay space.
-  * Contrary to `ct.pointer.xui` and `ct.pointer.yui`, these two can be changed by you. For example, you can limit the area a cursor inside an RTS game can move in, or move the cursor to specific buttons automatically as an accessibility feature.
-* `ct.pointer.xmovement` and `ct.pointer.ymovement` to read the movement speed of the pointer. These can be used, for example, to rotate camera in a shooter.
+* `pointer.xlocked` and `pointer.ylocked` to read the position of the pointer in UI space. Use `u.uiToGameCoord(pointer.xlocked, pointer.ylocked)` to convert them in gameplay space.
+  * Contrary to `pointer.xui` and `pointer.yui`, these two can be changed by you. For example, you can limit the area a cursor inside an RTS game can move in, or move the cursor to specific buttons automatically as an accessibility feature.
+* `pointer.xmovement` and `pointer.ymovement` to read the movement speed of the pointer. These can be used, for example, to rotate camera in a shooter.
 
 ## Getting whether a pointer is locked
 
-A property `ct.pointer.locked` tells whether a pointer is currently locked (`true`) or not (`false`).
-This property may be `false` after calling `ct.pointer.lock()` in several cases:
+A property `pointer.locked` tells whether a pointer is currently locked (`true`) or not (`false`).
+This property may be `false` after calling `pointer.lock()` in several cases:
 
 * A player switched to another app;
 * A player interrupted the pointer lock with the Escape key;
 * Pointer Lock is not supported in player's browser. This may happen on several mobile browsers, notably with Samsung's browser, and in Internet Explorer.
 
-In any case, `ct.pointer` will lock the pointer again once a user clicks inside the game's window.
+In any case, `pointer` will lock the pointer again once a user clicks inside the game's window.

--- a/app/data/ct.libs/pointer/docs/Reading pointer properties.md
+++ b/app/data/ct.libs/pointer/docs/Reading pointer properties.md
@@ -2,33 +2,33 @@
 
 `ct.pointer` tracks all the current pointers on-screen, but selects one as a **primary pointer**. For touch-only devices, it will be the first touch in a multi-touch session. For devices with mouse, it will probably be the mouse.
 
-The properties of a primary pointer can be read with these properties (in form of `ct.pointer.x`, `ct.pointer.y` and so on):
+The properties of a primary pointer can be read with these properties (in form of `pointer.x`, `pointer.y` and so on):
 
 * `x`, `y` — the current position of the pointer in gameplay coordinates;
 * `xprev`, `yprev` — the position of the pointer in gameplay coordinates during the passed frame;
 * `xui`, `yui` — the current position of the pointer in UI coordinates;
 * `xuiprev`, `yuiprev` — the position of the pointer in UI coordinates during the passed frame;
 * `pressure` — a float between 0 and 1 representing the pressure dealt on the pointer (think of a tablet pen where values close to 0 represent light strokes, and values close to 1 — ones made with strong pressure);
-* `buttons` — a bit mask showing which buttons are pressed on the pointer's device. Use `ct.pointer.isButtonPressed` to get whether a particular button is pressed. See more info about the `buttons` property on [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events#determining_button_states).
+* `buttons` — a bit mask showing which buttons are pressed on the pointer's device. Use `pointer.isButtonPressed` to get whether a particular button is pressed. See more info about the `buttons` property on [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events#determining_button_states).
 * `tiltX`, `tiltY` — floats between -90 and 90 indicating a pen's tilt.
 * `twist` — a value between 0 and 360 indicating the rotation of the pointer's device, clockwise.
 * `width`, `height` — the size of the pointer in gameplay coordinates.
 * `type` — usually is `'mouse'`, `'pen'`, or `'touch'`. Tells which device is used as a primary pointer.
 
-You can also read pointers from arrays `ct.pointer.hover`, `ct.pointer.down`, and `ct.pointer.released`. These have all the current pointer events in three different states. **Note that pointers that are currently pressed down also count as hovering pointers.**
+You can also read pointers from arrays `pointer.hover`, `pointer.down`, and `pointer.released`. These have all the current pointer events in three different states. **Note that pointers that are currently pressed down also count as hovering pointers.**
 
-Besides that, you can get pointers from methods `ct.pointer.hovers`, `ct.pointer.collides`, and from their UI-space versions. All these pointer objects have the same properties as `ct.pointer`.
+Besides that, you can get pointers from methods `pointer.hovers`, `pointer.collides`, and from their UI-space versions. All these pointer objects have the same properties as `pointer`.
 
 ## Getting currently pressed buttons
 
-Generally you will only need to use data from the Actions system, but if you need to check against a specific pointer, you can use the `ct.pointer.isButtonPressed` method. Consider the following example:
+Generally you will only need to use data from the Actions system, but if you need to check against a specific pointer, you can use the `pointer.isButtonPressed` method. Consider the following example:
 
 ```js
 // Say, `this` is a UI button that queues units production in RTS or production facilities in a clicker game.
-const pointer = ct.pointer.collidesUi(this);
+const pointer = pointer.collidesUi(this);
 if (pointer) {
     // Was the secondary button pressed? (Right-click for mouse, additional buttons for tablet pens)
-    if (ct.pointer.isButtonPressed(pointer, 'Secondary')) {
+    if (pointer.isButtonPressed(pointer, 'Secondary')) {
         buyFive('Tanks');
     } else {
         buyOne('Tanks');

--- a/app/data/ct.libs/sprite/README.md
+++ b/app/data/ct.libs/sprite/README.md
@@ -7,7 +7,7 @@ The workflow of this module is simple: you add one function call, giving an exis
 # ![Source strip](./data/ct.libs/sprite/SlimeExample.png)
 # +
 ```js
-ct.sprite(
+sprite(
     'Slime', 'Slime_Idle',
     [0, 1, 2, 3, 2, 1, 0, 0, 0, 4, 5, 4, 0, 4, 5, 4]
 );
@@ -22,16 +22,16 @@ this.tex = 'Slime_Idle';
 If we would like to split the source strip into tho separate animations, we would do this:
 
 ```js
-ct.sprite(
+sprite(
     'Slime', 'Slime_Blink',
     [0, 1, 2, 3, 2, 1, 0, 0, 0]
 );
-ct.sprite(
+sprite(
     'Slime', 'Slime_Wiggle',
     [0, 4, 5, 4]
 );
 /* Later, in project's code */
-this.tex = ct.random.dice('Slime_Blink', 'Slime_Wiggle);
+this.tex = random.dice('Slime_Blink', 'Slime_Wiggle);
 ```
 # =
 # ![Gif result](./data/ct.libs/sprite/SlimeExample_Blink.gif) or ![Gif result](./data/ct.libs/sprite/SlimeExample_Wiggle.gif)

--- a/app/data/ct.libs/yarn/DOCS.md
+++ b/app/data/ct.libs/yarn/DOCS.md
@@ -1,10 +1,10 @@
 ## Loading a story
 
-### ct.yarn.openStory(data) ⇒ `YarnStory`
+### yarn.openStory(data) ⇒ `YarnStory`
 
 Opens the given JSON object and returns a YarnStory object, ready for playing.
 
-### ct.yarn.openFromFile(path) ⇒ `Promise<YarnStory>`
+### yarn.openFromFile(path) ⇒ `Promise<YarnStory>`
 
 Opens the given JSON file and returns a promise that resolves into a YarnStory.
 


### PR DESCRIPTION
Catmods no longer use `ct.catmodname`, but that wasn't changed in some catmods' docs. This pull request changes that, and updates a few typedefs as well.

**Changes proposed in this pull request:**

- Changes `ct.catmodname.` to `catmodname.` in catmod docs 
- Uses `catmodname` instead of `ct { catmodname...` in namespace declaration in typedefs
  - (in catmods that have already changed their index.js to actually drop `ct.`)

**Ping @CosmoMyzrailGorynych**
