### PR TITLE
ignore actions on not-yet loaded sounds; improve migration :zap: 

### DIFF
--- a/src/ct.release/sounds.ts
+++ b/src/ct.release/sounds.ts
@@ -100,6 +100,8 @@ const randomRange = (min: number, max: number): number => Math.random() * (max -
 /**
  * Applies a method onto a sound — regardless whether it is a sound exported from ct.IDE
  * (with variants) or imported by a user though `res.loadSound`.
+ *
+ * Ignore sounds that have not yet been loaded.
  */
 const withSound = <T>(name: string, fn: (sound: Sound, assetName: string) => T): T => {
     const pixiFind = PIXI.sound.exists(name) && PIXI.sound.find(name);
@@ -113,7 +115,9 @@ const withSound = <T>(name: string, fn: (sound: Sound, assetName: string) => T):
         let lastVal: T;
         for (const variant of soundMap[name].variants) {
             const assetName = `${pixiSoundPrefix}${variant.uid}`;
-            lastVal = fn(pixiSoundInstances[assetName], assetName);
+	    if (assetName in pixiSoundInstances) {
+		lastVal = fn(pixiSoundInstances[assetName], assetName);
+	    } // ignore sound variants not yet loaded
         }
         return lastVal!;
     }
@@ -365,7 +369,8 @@ export const soundsLib = {
             return pixiSoundInstances[name].isPlaying;
         } else if (name in soundMap) {
             for (const variant of soundMap[name].variants) {
-                if (pixiSoundInstances[`${pixiSoundPrefix}${variant.uid}`].isPlaying) {
+                const instanceKey = `${pixiSoundPrefix}${variant.uid}`;
+                if (instanceKey in pixiSoundInstances && pixiSoundInstances[instanceKey].isPlaying) {
                     return true;
                 }
             }

--- a/src/ct.release/sounds.ts
+++ b/src/ct.release/sounds.ts
@@ -115,9 +115,9 @@ const withSound = <T>(name: string, fn: (sound: Sound, assetName: string) => T):
         let lastVal: T;
         for (const variant of soundMap[name].variants) {
             const assetName = `${pixiSoundPrefix}${variant.uid}`;
-	    if (assetName in pixiSoundInstances) {
-		lastVal = fn(pixiSoundInstances[assetName], assetName);
-	    } // ignore sound variants not yet loaded
+            if (assetName in pixiSoundInstances) {
+                lastVal = fn(pixiSoundInstances[assetName], assetName);
+            } // ignore sound variants not yet loaded
         }
         return lastVal!;
     }
@@ -370,7 +370,9 @@ export const soundsLib = {
         } else if (name in soundMap) {
             for (const variant of soundMap[name].variants) {
                 const instanceKey = `${pixiSoundPrefix}${variant.uid}`;
-                if (instanceKey in pixiSoundInstances && pixiSoundInstances[instanceKey].isPlaying) {
+                if (instanceKey in pixiSoundInstances &&
+                    pixiSoundInstances[instanceKey].isPlaying
+                ) {
                     return true;
                 }
             }

--- a/src/js/projectMigrationScripts/4.0.0-next-1.js
+++ b/src/js/projectMigrationScripts/4.0.0-next-1.js
@@ -12,11 +12,12 @@ window.migrationProcess.push({
         }
         delete project.libs.fittoscreen;
         delete project.libs.touch;
+        delete project.libs.mouse;
         delete project.libs['sound.howler'];
         delete project.libs['sound.basic'];
 
         // `ct.` prefix drop
-        const regex = /ct\.(meta|camera|templates|rooms|actions|inputs|content|backgrounds|styles|res|emitters|tilemaps|timer|u|pixiApp|stage|loop|fittoscreen|assert|capture|cutscene|desktop|eqs|filters|flow|fs|gamedistribution|inherit|gamepad|keyboard|mouse|pointer|nakama|noise|nanoid|place|random|sprite|storage|touch|transition|ulid|vgui|vkeys|yarn)/g;
+        const regex = /ct\.(meta|camera|templates|rooms|actions|inputs|content|backgrounds|styles|res|emitters|tilemaps|timer|u|pixiApp|stage|loop|fittoscreen|assert|capture|cutscene|desktop|eqs|filters|flow|fs|gamedistribution|inherit|gamepad|keyboard|mouse|pointer|nakama|noise|nanoid|place|random|sprite|storage|touch|transition|tween|ulid|vgui|vkeys|yarn)/g;
         const regexSound = /ct\.sound/g;
         const regexDelta = /ct\.delta/g;
         const regexRoom = /ct\.room/g;


### PR DESCRIPTION
- sound actions on sounds that haven't been loaded are now ignored
- sound.playing returns false for sounds not yet loaded instead of crashing
- strip ct from ct.tween
- delete deprecated mouse catmod on 4.0.1 migration to prevent crash


partially resolves #507 
<!-- Please delete this line if you're creating a pull request inside your own repo -->
<!-- I get spammed by your upstream pulls 😹 -->
**Ping @CosmoMyzrailGorynych**
